### PR TITLE
Using objects from k8s.io/api instead of k8s.io/client-go

### DIFF
--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -8,12 +8,12 @@ import (
 	"time"
 
 	"github.com/portworx/sched-ops/task"
+	apps_api "k8s.io/api/apps/v1beta1"
+	"k8s.io/api/core/v1"
+	storage_api "k8s.io/api/storage/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/typed/apps/v1beta1"
-	"k8s.io/client-go/pkg/api/v1"
-	apps_api "k8s.io/client-go/pkg/apis/apps/v1beta1"
-	storage_api "k8s.io/client-go/pkg/apis/storage/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	k8shelper "k8s.io/kubernetes/pkg/api/v1/helper"
@@ -252,8 +252,7 @@ func (k *k8sOps) IsNodeReady(name string) error {
 		case v1.NodeConditionType(v1.NodeOutOfDisk),
 			v1.NodeConditionType(v1.NodeMemoryPressure),
 			v1.NodeConditionType(v1.NodeDiskPressure),
-			v1.NodeConditionType(v1.NodeNetworkUnavailable),
-			v1.NodeConditionType(v1.NodeInodePressure):
+			v1.NodeConditionType(v1.NodeNetworkUnavailable):
 			if condition.Status != v1.ConditionStatus(v1.ConditionFalse) {
 				return fmt.Errorf("node: %v is not ready as condition: %v (%v) is %v. Reason: %v",
 					name, condition.Type, condition.Message, condition.Status, condition.Reason)
@@ -552,8 +551,9 @@ func (k *k8sOps) ValidateDeployment(deployment *apps_api.Deployment) error {
 				if vol.PersistentVolumeClaim != nil {
 					foundPVC = true
 
-					claim, err := k.client.PersistentVolumeClaims(dep.Namespace).Get(vol.PersistentVolumeClaim.ClaimName,
-						meta_v1.GetOptions{})
+					claim, err := k.client.CoreV1().
+						PersistentVolumeClaims(dep.Namespace).
+						Get(vol.PersistentVolumeClaim.ClaimName, meta_v1.GetOptions{})
 					if err != nil {
 						return "", err
 					}
@@ -671,7 +671,7 @@ func (k *k8sOps) GetDeploymentPods(deployment *apps_api.Deployment) ([]v1.Pod, e
 		return nil, err
 	}
 
-	rSets, err := k.client.ReplicaSets(deployment.Namespace).List(meta_v1.ListOptions{})
+	rSets, err := k.client.AppsV1beta2().ReplicaSets(deployment.Namespace).List(meta_v1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -846,7 +846,7 @@ func (k *k8sOps) GetPods(namespace string) (*v1.PodList, error) {
 		return nil, err
 	}
 
-	return k.client.Pods(namespace).List(meta_v1.ListOptions{})
+	return k.client.CoreV1().Pods(namespace).List(meta_v1.ListOptions{})
 }
 
 func (k *k8sOps) GetPodsByOwner(ownerName string, namespace string) ([]v1.Pod, error) {
@@ -942,7 +942,7 @@ func (k *k8sOps) CreatePersistentVolumeClaim(pvc *v1.PersistentVolumeClaim) (*v1
 		ns = v1.NamespaceDefault
 	}
 
-	return k.client.PersistentVolumeClaims(ns).Create(pvc)
+	return k.client.CoreV1().PersistentVolumeClaims(ns).Create(pvc)
 }
 
 func (k *k8sOps) DeletePersistentVolumeClaim(pvc *v1.PersistentVolumeClaim) error {
@@ -950,7 +950,7 @@ func (k *k8sOps) DeletePersistentVolumeClaim(pvc *v1.PersistentVolumeClaim) erro
 		return err
 	}
 
-	return k.client.PersistentVolumeClaims(pvc.Namespace).Delete(pvc.Name, &meta_v1.DeleteOptions{})
+	return k.client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(pvc.Name, &meta_v1.DeleteOptions{})
 }
 
 func (k *k8sOps) ValidatePersistentVolumeClaim(pvc *v1.PersistentVolumeClaim) error {
@@ -959,7 +959,9 @@ func (k *k8sOps) ValidatePersistentVolumeClaim(pvc *v1.PersistentVolumeClaim) er
 			return "", err
 		}
 
-		result, err := k.client.PersistentVolumeClaims(pvc.Namespace).Get(pvc.Name, meta_v1.GetOptions{})
+		result, err := k.client.CoreV1().
+			PersistentVolumeClaims(pvc.Namespace).
+			Get(pvc.Name, meta_v1.GetOptions{})
 		if err != nil {
 			return "", err
 		}
@@ -985,7 +987,9 @@ func (k *k8sOps) GetVolumeForPersistentVolumeClaim(pvc *v1.PersistentVolumeClaim
 		return "", err
 	}
 
-	result, err := k.client.PersistentVolumeClaims(pvc.Namespace).Get(pvc.Name, meta_v1.GetOptions{})
+	result, err := k.client.CoreV1().
+		PersistentVolumeClaims(pvc.Namespace).
+		Get(pvc.Name, meta_v1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -998,7 +1002,7 @@ func (k *k8sOps) GetPersistentVolumeClaimStatus(pvc *v1.PersistentVolumeClaim) (
 		return nil, err
 	}
 
-	result, err := k.client.PersistentVolumeClaims(pvc.Namespace).Get(pvc.Name, meta_v1.GetOptions{})
+	result, err := k.client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(pvc.Name, meta_v1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -1013,7 +1017,7 @@ func (k *k8sOps) GetPersistentVolumeClaimParams(pvc *v1.PersistentVolumeClaim) (
 
 	params := make(map[string]string)
 
-	result, err := k.client.PersistentVolumeClaims(pvc.Namespace).Get(pvc.Name, meta_v1.GetOptions{})
+	result, err := k.client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(pvc.Name, meta_v1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
k8s.io/api is going to be the canonical place for all api objects going forward