### PR TITLE
add api to return pods by node name

### DIFF
--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -221,6 +221,9 @@ type RBACOps interface {
 type PodOps interface {
 	// GetPods returns pods for the given namespace
 	GetPods(string) (*v1.PodList, error)
+	// GetPodsByNode returns all pods in given namespace and given k8s node name.
+	//  If namespace is empty, it will return pods from all namespaces
+	GetPodsByNode(nodeName, namespace string) (*v1.PodList, error)
 	// GetPodsByOwner returns pods for the given owner and namespace
 	GetPodsByOwner(types.UID, string) ([]v1.Pod, error)
 	// GetPodsUsingPV returns all pods in cluster using given pv
@@ -1607,6 +1610,22 @@ func (k *k8sOps) GetPods(namespace string) (*v1.PodList, error) {
 	}
 
 	return k.client.CoreV1().Pods(namespace).List(meta_v1.ListOptions{})
+}
+
+func (k *k8sOps) GetPodsByNode(nodeName, namespace string) (*v1.PodList, error) {
+	if len(nodeName) == 0 {
+		return nil, fmt.Errorf("node name is required for this API")
+	}
+
+	if err := k.initK8sClient(); err != nil {
+		return nil, err
+	}
+
+	listOptions := meta_v1.ListOptions{
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+	}
+
+	return k.client.CoreV1().Pods(namespace).List(listOptions)
 }
 
 func (k *k8sOps) GetPodsByOwner(ownerUID types.UID, namespace string) ([]v1.Pod, error) {


### PR DESCRIPTION
This will be used in portworx oci-monitor which first needs to get all pods running on a node and then internally filters pods that only use PX volumes.

Signed-off-by: Harsh Desai <harsh@portworx.com>