### PR TITLE
In error cases, always return stderr and don't fail API call if stder is present (some commands warn on stderr)

### DIFF
--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -863,11 +863,11 @@ func (k *k8sOps) RunCommandInPod(cmds []string, podName, containerName, namespac
 	})
 
 	if err != nil {
-		return "", fmt.Errorf("could not execute: %v", err)
+		return execErr.String(), fmt.Errorf("could not execute: %v", err)
 	}
 
 	if execErr.Len() > 0 {
-		return "", fmt.Errorf("stderr: %v", execErr.String())
+		return execErr.String(), nil
 	}
 
 	return execOut.String(), nil


### PR DESCRIPTION

Signed-off-by: Harsh Desai <harsh@portworx.com>