### PR TITLE
Don't proceed with daemonset validation if observed generation is still 0

### DIFF
--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -1244,6 +1244,13 @@ func (k *k8sOps) ValidateDaemonSet(name, namespace string, timeout time.Duration
 			return "", true, err
 		}
 
+		if ds.Status.ObservedGeneration == 0 {
+			return "", true, &ErrAppNotReady{
+				ID:    name,
+				Cause: "Observed generation is still 0. Check back status after some time",
+			}
+		}
+
 		pods, err := k.GetDaemonSetPods(ds)
 		if err != nil || pods == nil {
 			return "", true, &ErrAppNotReady{
@@ -1256,13 +1263,6 @@ func (k *k8sOps) ValidateDaemonSet(name, namespace string, timeout time.Duration
 			return "", true, &ErrAppNotReady{
 				ID:    ds.Name,
 				Cause: "DaemonSet has 0 pods",
-			}
-		}
-
-		if ds.Status.ObservedGeneration == 0 {
-			return "", true, &ErrAppNotReady{
-				ID:    name,
-				Cause: "Observed generation is still 0. Check back status after some time",
 			}
 		}
 

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -1259,6 +1259,13 @@ func (k *k8sOps) ValidateDaemonSet(name, namespace string, timeout time.Duration
 			}
 		}
 
+		if ds.Status.ObservedGeneration == 0 {
+			return "", true, &ErrAppNotReady{
+				ID:    name,
+				Cause: "Observed generation is still 0. Check back status after some time",
+			}
+		}
+
 		podsOverviewString := k.generatePodsOverviewString(pods)
 
 		if ds.Status.DesiredNumberScheduled != ds.Status.UpdatedNumberScheduled {


### PR DESCRIPTION
0 observed generation would mean the daemonset controller hasn't even started monitoring the daemonset. https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#daemonsetstatus-v1-apps

This was causing issues where other jobs like talisman declared daemonsets as ready even before they started deploying.

Signed-off-by: Harsh Desai <harsh@portworx.com>