### PR TITLE
Allow to set new instance from kubeconfig file

### DIFF
--- a/k8s/errors.go
+++ b/k8s/errors.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"errors"
 	"fmt"
+	"reflect"
 )
 
 // ErrK8SApiAccountNotSet is returned when the account used to talk to k8s api is not setup
@@ -116,14 +117,16 @@ func (e *ErrSnapshotDataFailed) Error() string {
 	return fmt.Sprintf("SnapshotData %v has failed. Cause: %v", e.ID, e.Cause)
 }
 
-// ErrFailedToApplyCustomSpec error type when CRD objects does not applied successfully
-type ErrFailedToApplyCustomSpec struct {
+// ErrFailedToValidateCustomSpec error type when CRD objects does not applied successfully
+type ErrFailedToValidateCustomSpec struct {
 	// Name of CRD object
 	Name string
 	// Cause is the underlying cause of the error
 	Cause string
+	// Type is the underlying type of CRD objects
+	Type interface{}
 }
 
-func (e *ErrFailedToApplyCustomSpec) Error() string {
-	return fmt.Sprintf("Failed to apply custom spec : %v due to err: %v", e.Name, e.Cause)
+func (e *ErrFailedToValidateCustomSpec) Error() string {
+	return fmt.Sprintf("Failed to apply custom spec : %v of type %v due to err: %v", e.Name, reflect.TypeOf(e.Type), e.Cause)
 }

--- a/k8s/errors.go
+++ b/k8s/errors.go
@@ -115,3 +115,15 @@ type ErrSnapshotDataFailed struct {
 func (e *ErrSnapshotDataFailed) Error() string {
 	return fmt.Sprintf("SnapshotData %v has failed. Cause: %v", e.ID, e.Cause)
 }
+
+// ErrFailedToApplyCustomSpec error type when CRD objects does not applied successfully
+type ErrFailedToApplyCustomSpec struct {
+	// Name of CRD object
+	Name string
+	// Cause is the underlying cause of the error
+	Cause string
+}
+
+func (e *ErrFailedToApplyCustomSpec) Error() string {
+	return fmt.Sprintf("Failed to apply custom spec : %v due to err: %v", e.Name, e.Cause)
+}


### PR DESCRIPTION
This PR add support in k8s to return new k8s instance to be set. Will be required in case of multiple k8s client access.
-  It adds ValidateClusterpair() and VaildateMigration() api to check status
