### PR TITLE
add list options to watch pods API

### DIFF
--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -327,7 +327,7 @@ type PodOps interface {
 	// ValidatePod validates the given pod if it's ready
 	ValidatePod(pod *v1.Pod, timeout, retryInterval time.Duration) error
 	// WatchPods sets up a watcher that listens for the changes to pods in given namespace
-	WatchPods(namespace string, fn WatchFunc) error
+	WatchPods(namespace string, fn WatchFunc, listOptions meta_v1.ListOptions) error
 }
 
 // StorageClassOps is an interface to perform k8s storage class operations
@@ -957,7 +957,8 @@ func (k *k8sOps) handleWatch(
 	watchInterface watch.Interface,
 	object runtime.Object,
 	namespace string,
-	fn WatchFunc) {
+	fn WatchFunc,
+	listOptions meta_v1.ListOptions) {
 	for {
 		select {
 		case event, more := <-watchInterface.ResultChan():
@@ -971,7 +972,7 @@ func (k *k8sOps) handleWatch(
 					} else if cm, ok := object.(*v1.ConfigMap); ok {
 						err = k.WatchConfigMap(cm, fn)
 					} else if _, ok := object.(*v1.Pod); ok {
-						err = k.WatchPods(namespace, fn)
+						err = k.WatchPods(namespace, fn, listOptions)
 					} else {
 						return "", false, fmt.Errorf("unsupported object: %v given to handle watch", object)
 					}
@@ -1012,7 +1013,7 @@ func (k *k8sOps) WatchNode(node *v1.Node, watchNodeFn WatchFunc) error {
 	}
 
 	// fire off watch function
-	go k.handleWatch(watchInterface, node, "", watchNodeFn)
+	go k.handleWatch(watchInterface, node, "", watchNodeFn, listOptions)
 	return nil
 }
 
@@ -2406,15 +2407,12 @@ func (k *k8sOps) ValidatePod(pod *v1.Pod, timeout, retryInterval time.Duration) 
 	return nil
 }
 
-func (k *k8sOps) WatchPods(namespace string, fn WatchFunc) error {
+func (k *k8sOps) WatchPods(namespace string, fn WatchFunc, listOptions meta_v1.ListOptions) error {
 	if err := k.initK8sClient(); err != nil {
 		return err
 	}
 
-	listOptions := meta_v1.ListOptions{
-		Watch: true,
-	}
-
+	listOptions.Watch = true
 	watchInterface, err := k.client.Core().Pods(namespace).Watch(listOptions)
 	if err != nil {
 		logrus.WithError(err).Error("error invoking the watch api for pods")
@@ -2426,7 +2424,8 @@ func (k *k8sOps) WatchPods(namespace string, fn WatchFunc) error {
 		watchInterface,
 		&v1.Pod{},
 		namespace,
-		fn)
+		fn,
+		listOptions)
 
 	return nil
 }
@@ -3338,7 +3337,7 @@ func (k *k8sOps) WatchConfigMap(configMap *v1.ConfigMap, fn WatchFunc) error {
 	}
 
 	// fire off watch function
-	go k.handleWatch(watchInterface, configMap, "", fn)
+	go k.handleWatch(watchInterface, configMap, "", fn, listOptions)
 	return nil
 }
 


### PR DESCRIPTION
This is needed to filter the pods that we watch for.

One use case is Portworx needs to just watch for pods with labels `name=portworx` on a given node.

Signed-off-by: Harsh Desai <harsh@portworx.com>