### PR TITLE
Return detailed error when tasks time out

### DIFF
--- a/task/task.go
+++ b/task/task.go
@@ -1,7 +1,7 @@
 package task
 
 import (
-	"errors"
+	"fmt"
 	"log"
 	"time"
 )
@@ -9,7 +9,14 @@ import (
 //TODO: export the type: type Task func() (string, error)
 
 // ErrTimedOut is returned when an operation times out
-var ErrTimedOut = errors.New("timed out performing task")
+type ErrTimedOut struct {
+	// Reason is the reason for the timeout
+	Reason string
+}
+
+func (e *ErrTimedOut) Error() string {
+	return fmt.Sprintf("timed out performing task. Error was: %s", e.Reason)
+}
 
 // DoRetryWithTimeout performs given task with given timeout and timeBeforeRetry
 func DoRetryWithTimeout(t func() (interface{}, bool, error), timeout, timeBeforeRetry time.Duration) (interface{}, error) {
@@ -48,6 +55,8 @@ func DoRetryWithTimeout(t func() (interface{}, bool, error), timeout, timeBefore
 		return out, err
 	case <-time.After(timeout):
 		quit <- true
-		return out, ErrTimedOut
+		return out, &ErrTimedOut{
+			Reason: err.Error(),
+		}
 	}
 }

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -1,0 +1,41 @@
+package task
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDoRetry(t *testing.T) {
+	t1 := func() (interface{}, bool, error) {
+		return "hello world", false, nil
+	}
+
+	output, err := DoRetryWithTimeout(t1, 1*time.Minute, 5*time.Second)
+	require.NoError(t, err, "failed to run task")
+	require.NotEmpty(t, output, "ask returned empty output")
+
+	t2 := func() (interface{}, bool, error) {
+		return "", true, fmt.Errorf("task is failing")
+	}
+
+	retryTill := time.Now().Add(10 * time.Second)
+	output, err = DoRetryWithTimeout(t2, 10*time.Second, 2*time.Second)
+	require.Error(t, err, "task was expected to fail")
+	require.Empty(t, output, "task should have returned empty output")
+	require.True(t, time.Now().After(retryTill) || time.Now().Equal(retryTill), "current time should be after expected timeout")
+
+	// tighter retry loop
+	t3 := func() (interface{}, bool, error) {
+		return "", true, fmt.Errorf("task is failing")
+	}
+
+	retryTill = time.Now().Add(2 * time.Second)
+	output, err = DoRetryWithTimeout(t3, 2*time.Second, 10*time.Millisecond)
+	require.Error(t, err, "task was expected to fail")
+	require.Empty(t, output, "task should have returned empty output")
+	require.True(t, time.Now().After(retryTill) || time.Now().Equal(retryTill), "current time should be after expected timeout")
+
+}


### PR DESCRIPTION
Currently the method just returns "timed out performing task" and eats up the original error. 

Now returning the original error which will be useful in logs and also for clients to parse the error string.

Checked other repos and none currently is parsing the return type. So the API change should be okay.

Signed-off-by: Harsh Desai <harsh@portworx.com>