### PR TITLE
Update placement APIs to use v1beta2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -250,18 +250,19 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:cfe8d419eb553560ba1e297dc0430a161be3239372a9fd60111e63da3b75fdb8"
+  branch = "placement-v2"
+  digest = "1:bdd967334d0d0057bea0b9a823bf6cecf075a9ae3dd4945e6138788ba6dddcbe"
   name = "github.com/portworx/talisman"
   packages = [
     "pkg/apis/portworx",
     "pkg/apis/portworx/v1beta1",
+    "pkg/apis/portworx/v1beta2",
     "pkg/client/clientset/versioned",
     "pkg/client/clientset/versioned/scheme",
-    "pkg/client/clientset/versioned/typed/portworx/v1beta1",
+    "pkg/client/clientset/versioned/typed/portworx/v1beta2",
   ]
   pruneopts = "UT"
-  revision = "73c47f96b4178a49863212c1e3212a0c07678599"
+  revision = "0478126e6190edf1cbecd27d1f46d5e3cbe01e3c"
 
 [[projects]]
   digest = "1:87c2e02fb01c27060ccc5ba7c5a407cc91147726f8f40b70cceeedbc52b1f3a8"
@@ -599,7 +600,7 @@
     "github.com/openshift/api/apps/v1",
     "github.com/openshift/client-go/apps/clientset/versioned",
     "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1",
-    "github.com/portworx/talisman/pkg/apis/portworx/v1beta1",
+    "github.com/portworx/talisman/pkg/apis/portworx/v1beta2",
     "github.com/portworx/talisman/pkg/client/clientset/versioned",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/require",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,6 +34,10 @@
   branch = "master"
   name = "github.com/libopenstorage/stork"
 
+[[override]]
+  branch = "placement-v2"
+  name = "github.com/portworx/talisman"
+
 [[constraint]]
   version = "kubernetes-1.11.0"
   name = "k8s.io/api"

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -18,7 +18,7 @@ import (
 	ocp_clientset "github.com/openshift/client-go/apps/clientset/versioned"
 	ocp_appsv1_client "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
 	"github.com/portworx/sched-ops/task"
-	talisman_v1beta1 "github.com/portworx/talisman/pkg/apis/portworx/v1beta1"
+	talisman_v1beta2 "github.com/portworx/talisman/pkg/apis/portworx/v1beta2"
 	talismanclientset "github.com/portworx/talisman/pkg/client/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	apps_api "k8s.io/api/apps/v1beta2"
@@ -626,15 +626,15 @@ type SchedulePolicyOps interface {
 // VolumePlacementStrategyOps is an interface to perform CRUD volume placememt strategy ops
 type VolumePlacementStrategyOps interface {
 	// CreateVolumePlacementStrategy creates a new volume placement strategy
-	CreateVolumePlacementStrategy(spec *talisman_v1beta1.VolumePlacementStrategy) (*talisman_v1beta1.VolumePlacementStrategy, error)
+	CreateVolumePlacementStrategy(spec *talisman_v1beta2.VolumePlacementStrategy) (*talisman_v1beta2.VolumePlacementStrategy, error)
 	// UpdateVolumePlacementStrategy updates an existing volume placement strategy
-	UpdateVolumePlacementStrategy(spec *talisman_v1beta1.VolumePlacementStrategy) (*talisman_v1beta1.VolumePlacementStrategy, error)
+	UpdateVolumePlacementStrategy(spec *talisman_v1beta2.VolumePlacementStrategy) (*talisman_v1beta2.VolumePlacementStrategy, error)
 	// ListVolumePlacementStrategies lists all volume placement strategies
-	ListVolumePlacementStrategies() (*talisman_v1beta1.VolumePlacementStrategyList, error)
+	ListVolumePlacementStrategies() (*talisman_v1beta2.VolumePlacementStrategyList, error)
 	// DeleteVolumePlacementStrategy deletes the volume placement strategy with given name
 	DeleteVolumePlacementStrategy(name string) error
 	// GetVolumePlacementStrategy returns the volume placememt strategy with given name
-	GetVolumePlacementStrategy(name string) (*talisman_v1beta1.VolumePlacementStrategy, error)
+	GetVolumePlacementStrategy(name string) (*talisman_v1beta2.VolumePlacementStrategy, error)
 }
 
 type privateMethods interface {
@@ -4051,7 +4051,7 @@ func (k *k8sOps) ValidateCRD(resource CustomResource, timeout, retryInterval tim
 	})
 }
 
-func (k *k8sOps) CreateVolumePlacementStrategy(spec *talisman_v1beta1.VolumePlacementStrategy) (*talisman_v1beta1.VolumePlacementStrategy, error) {
+func (k *k8sOps) CreateVolumePlacementStrategy(spec *talisman_v1beta2.VolumePlacementStrategy) (*talisman_v1beta2.VolumePlacementStrategy, error) {
 	if err := k.initK8sClient(); err != nil {
 		return nil, err
 	}
@@ -4059,7 +4059,7 @@ func (k *k8sOps) CreateVolumePlacementStrategy(spec *talisman_v1beta1.VolumePlac
 	return k.talismanClient.Portworx().VolumePlacementStrategies().Create(spec)
 }
 
-func (k *k8sOps) UpdateVolumePlacementStrategy(spec *talisman_v1beta1.VolumePlacementStrategy) (*talisman_v1beta1.VolumePlacementStrategy, error) {
+func (k *k8sOps) UpdateVolumePlacementStrategy(spec *talisman_v1beta2.VolumePlacementStrategy) (*talisman_v1beta2.VolumePlacementStrategy, error) {
 	if err := k.initK8sClient(); err != nil {
 		return nil, err
 	}
@@ -4067,7 +4067,7 @@ func (k *k8sOps) UpdateVolumePlacementStrategy(spec *talisman_v1beta1.VolumePlac
 	return k.talismanClient.Portworx().VolumePlacementStrategies().Update(spec)
 }
 
-func (k *k8sOps) ListVolumePlacementStrategies() (*talisman_v1beta1.VolumePlacementStrategyList, error) {
+func (k *k8sOps) ListVolumePlacementStrategies() (*talisman_v1beta2.VolumePlacementStrategyList, error) {
 	if err := k.initK8sClient(); err != nil {
 		return nil, err
 	}
@@ -4084,7 +4084,7 @@ func (k *k8sOps) DeleteVolumePlacementStrategy(name string) error {
 	})
 }
 
-func (k *k8sOps) GetVolumePlacementStrategy(name string) (*talisman_v1beta1.VolumePlacementStrategy, error) {
+func (k *k8sOps) GetVolumePlacementStrategy(name string) (*talisman_v1beta2.VolumePlacementStrategy, error) {
 	if err := k.initK8sClient(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Due to cyclic dependency between CRD pkg and sched-ops, Gopkg.toml has an override right now. Will be removed once both are merged to master.

CRD PR: https://github.com/portworx/talisman/pull/88

CRD follows requirements at: https://docs.google.com/document/d/1CJbJoTVTmYJN2PZCyBVqL8hyQvfusXiYvDDidpJYdyo/edit#heading=h.em27vgxrk1os

