### PR TITLE
adding NewInstanceFromConfigFile function

### DIFF
--- a/k8s/admissionregistration/admissionregistration.go
+++ b/k8s/admissionregistration/admissionregistration.go
@@ -57,6 +57,17 @@ func NewForConfig(c *rest.Config) (*Client, error) {
 	}, nil
 }
 
+// NewInstanceFromConfigFile returns new instance of client by using given
+// config file
+func NewInstanceFromConfigFile(config string) (Ops, error) {
+	newInstance := &Client{}
+	err := newInstance.loadClientFromKubeconfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return newInstance, nil
+}
+
 // Client provides a wrapper for kubernetes admission interface.
 type Client struct {
 	config    *rest.Config

--- a/k8s/apiextensions/apiextensions.go
+++ b/k8s/apiextensions/apiextensions.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"sync"
 
-	"github.com/sirupsen/logrus"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
@@ -65,7 +64,6 @@ func NewInstanceFromConfigFile(config string) (Ops, error) {
 	newInstance := &Client{}
 	err := newInstance.loadClientFromKubeconfig(config)
 	if err != nil {
-		logrus.Errorf("Unable to set new instance: %v", err)
 		return nil, err
 	}
 	return newInstance, nil

--- a/k8s/apiextensions/apiextensions.go
+++ b/k8s/apiextensions/apiextensions.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/sirupsen/logrus"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
@@ -56,6 +57,18 @@ func NewForConfig(c *rest.Config) (*Client, error) {
 	return &Client{
 		extension: client,
 	}, nil
+}
+
+// NewInstanceFromConfigFile returns new instance of client by using given
+// config file
+func NewInstanceFromConfigFile(config string) (Ops, error) {
+	newInstance := &Client{}
+	err := newInstance.loadClientFromKubeconfig(config)
+	if err != nil {
+		logrus.Errorf("Unable to set new instance: %v", err)
+		return nil, err
+	}
+	return newInstance, nil
 }
 
 // Client provides a wrapper for kubernetes extension interface.

--- a/k8s/apps/apps.go
+++ b/k8s/apps/apps.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -67,6 +68,18 @@ func NewForConfig(c *rest.Config) (*Client, error) {
 		apps: apps,
 		core: core,
 	}, nil
+}
+
+// NewInstanceFromConfigFile returns new instance of client by using given
+// config file
+func NewInstanceFromConfigFile(config string) (Ops, error) {
+	newInstance := &Client{}
+	err := newInstance.loadClientFromKubeconfig(config)
+	if err != nil {
+		logrus.Errorf("Unable to set new instance: %v", err)
+		return nil, err
+	}
+	return newInstance, nil
 }
 
 // Client provides a wrapper for the kubernetes apps client.

--- a/k8s/apps/apps.go
+++ b/k8s/apps/apps.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"sync"
 
-	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -76,7 +75,6 @@ func NewInstanceFromConfigFile(config string) (Ops, error) {
 	newInstance := &Client{}
 	err := newInstance.loadClientFromKubeconfig(config)
 	if err != nil {
-		logrus.Errorf("Unable to set new instance: %v", err)
 		return nil, err
 	}
 	return newInstance, nil

--- a/k8s/autopilot/autopilot.go
+++ b/k8s/autopilot/autopilot.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	autopilotclientset "github.com/libopenstorage/autopilot-api/pkg/client/clientset/versioned"
+	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -53,6 +54,18 @@ func NewForConfig(cfg *rest.Config) (*Client, error) {
 	return &Client{
 		autopilot: client,
 	}, nil
+}
+
+// NewInstanceFromConfigFile returns new instance of client by using given
+// config file
+func NewInstanceFromConfigFile(config string) (Ops, error) {
+	newInstance := &Client{}
+	err := newInstance.loadClientFromKubeconfig(config)
+	if err != nil {
+		logrus.Errorf("Unable to set new instance: %v", err)
+		return nil, err
+	}
+	return newInstance, nil
 }
 
 // Client provides a wrapper for the autopilot client.

--- a/k8s/autopilot/autopilot.go
+++ b/k8s/autopilot/autopilot.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	autopilotclientset "github.com/libopenstorage/autopilot-api/pkg/client/clientset/versioned"
-	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -62,7 +61,6 @@ func NewInstanceFromConfigFile(config string) (Ops, error) {
 	newInstance := &Client{}
 	err := newInstance.loadClientFromKubeconfig(config)
 	if err != nil {
-		logrus.Errorf("Unable to set new instance: %v", err)
 		return nil, err
 	}
 	return newInstance, nil

--- a/k8s/batch/batch.go
+++ b/k8s/batch/batch.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"sync"
 
-	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
 	"k8s.io/client-go/rest"
@@ -65,7 +64,6 @@ func NewInstanceFromConfigFile(config string) (Ops, error) {
 	newInstance := &Client{}
 	err := newInstance.loadClientFromKubeconfig(config)
 	if err != nil {
-		logrus.Errorf("Unable to set new instance: %v", err)
 		return nil, err
 	}
 	return newInstance, nil

--- a/k8s/batch/batch.go
+++ b/k8s/batch/batch.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
 	"k8s.io/client-go/rest"
@@ -56,6 +57,18 @@ func NewForConfig(c *rest.Config) (*Client, error) {
 	return &Client{
 		batch: batch,
 	}, nil
+}
+
+// NewInstanceFromConfigFile returns new instance of client by using given
+// config file
+func NewInstanceFromConfigFile(config string) (Ops, error) {
+	newInstance := &Client{}
+	err := newInstance.loadClientFromKubeconfig(config)
+	if err != nil {
+		logrus.Errorf("Unable to set new instance: %v", err)
+		return nil, err
+	}
+	return newInstance, nil
 }
 
 // Client is a wrapper for the kubernetes batch client.

--- a/k8s/core/core.go
+++ b/k8s/core/core.go
@@ -96,6 +96,18 @@ func NewForConfig(c *rest.Config) (*Client, error) {
 	}, nil
 }
 
+// NewInstanceFromConfigFile returns new instance of client by using given
+// config file
+func NewInstanceFromConfigFile(config string) (Ops, error) {
+	newInstance := &Client{}
+	err := newInstance.loadClientFromKubeconfig(config)
+	if err != nil {
+		logrus.Errorf("Unable to set new instance: %v", err)
+		return nil, err
+	}
+	return newInstance, nil
+}
+
 // Client is a wrapper for kubernetes core client.
 type Client struct {
 	config     *rest.Config

--- a/k8s/core/core.go
+++ b/k8s/core/core.go
@@ -36,6 +36,7 @@ var (
 // Ops is an interface to perform kubernetes related operations on the core resources.
 type Ops interface {
 	ConfigMapOps
+	EventOps
 	NamespaceOps
 	NodeOps
 	PersistentVolumeClaimOps
@@ -102,7 +103,6 @@ func NewInstanceFromConfigFile(config string) (Ops, error) {
 	newInstance := &Client{}
 	err := newInstance.loadClientFromKubeconfig(config)
 	if err != nil {
-		logrus.Errorf("Unable to set new instance: %v", err)
 		return nil, err
 	}
 	return newInstance, nil

--- a/k8s/core/core.go
+++ b/k8s/core/core.go
@@ -123,6 +123,7 @@ func (c *Client) SetConfig(cfg *rest.Config) {
 	c.storage = nil
 }
 
+// GetVersion returns server version
 func (c *Client) GetVersion() (*version.Info, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err

--- a/k8s/dynamic/dynamic.go
+++ b/k8s/dynamic/dynamic.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -63,6 +64,18 @@ func NewForConfig(c *rest.Config) (*Client, error) {
 	return &Client{
 		client: client,
 	}, nil
+}
+
+// NewInstanceFromConfigFile returns new instance of client by using given
+// config file
+func NewInstanceFromConfigFile(config string) (Ops, error) {
+	newInstance := &Client{}
+	err := newInstance.loadClientFromKubeconfig(config)
+	if err != nil {
+		logrus.Errorf("Unable to set new instance: %v", err)
+		return nil, err
+	}
+	return newInstance, nil
 }
 
 // Client is a wrapper for the kubernetes dynamic client.

--- a/k8s/dynamic/dynamic.go
+++ b/k8s/dynamic/dynamic.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -72,7 +71,6 @@ func NewInstanceFromConfigFile(config string) (Ops, error) {
 	newInstance := &Client{}
 	err := newInstance.loadClientFromKubeconfig(config)
 	if err != nil {
-		logrus.Errorf("Unable to set new instance: %v", err)
 		return nil, err
 	}
 	return newInstance, nil

--- a/k8s/externalstorage/externalstorage.go
+++ b/k8s/externalstorage/externalstorage.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	snapclient "github.com/kubernetes-incubator/external-storage/snapshot/pkg/client"
+	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -53,6 +54,18 @@ func NewForConfig(c *rest.Config) (*Client, error) {
 	return &Client{
 		snap: snap,
 	}, nil
+}
+
+// NewInstanceFromConfigFile returns new instance of client by using given
+// config file
+func NewInstanceFromConfigFile(config string) (Ops, error) {
+	newInstance := &Client{}
+	err := newInstance.loadClientFromKubeconfig(config)
+	if err != nil {
+		logrus.Errorf("Unable to set new instance: %v", err)
+		return nil, err
+	}
+	return newInstance, nil
 }
 
 // Client is a wrapper for the external-storage client.

--- a/k8s/externalstorage/externalstorage.go
+++ b/k8s/externalstorage/externalstorage.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	snapclient "github.com/kubernetes-incubator/external-storage/snapshot/pkg/client"
-	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -62,7 +61,6 @@ func NewInstanceFromConfigFile(config string) (Ops, error) {
 	newInstance := &Client{}
 	err := newInstance.loadClientFromKubeconfig(config)
 	if err != nil {
-		logrus.Errorf("Unable to set new instance: %v", err)
 		return nil, err
 	}
 	return newInstance, nil

--- a/k8s/openshift/openshift.go
+++ b/k8s/openshift/openshift.go
@@ -7,6 +7,7 @@ import (
 
 	ocpclientset "github.com/openshift/client-go/apps/clientset/versioned"
 	ocpsecurityclientset "github.com/openshift/client-go/security/clientset/versioned"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -73,6 +74,18 @@ func NewForConfig(c *rest.Config) (*Client, error) {
 		ocpClient:         ocpClient,
 		ocpSecurityClient: ocpSecurityClient,
 	}, nil
+}
+
+// NewInstanceFromConfigFile returns new instance of client by using given
+// config file
+func NewInstanceFromConfigFile(config string) (Ops, error) {
+	newInstance := &Client{}
+	err := newInstance.loadClientFromKubeconfig(config)
+	if err != nil {
+		logrus.Errorf("Unable to set new instance: %v", err)
+		return nil, err
+	}
+	return newInstance, nil
 }
 
 // Client is a wrapper for the openshift resource interfaces.

--- a/k8s/openshift/openshift.go
+++ b/k8s/openshift/openshift.go
@@ -7,7 +7,6 @@ import (
 
 	ocpclientset "github.com/openshift/client-go/apps/clientset/versioned"
 	ocpsecurityclientset "github.com/openshift/client-go/security/clientset/versioned"
-	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -82,7 +81,6 @@ func NewInstanceFromConfigFile(config string) (Ops, error) {
 	newInstance := &Client{}
 	err := newInstance.loadClientFromKubeconfig(config)
 	if err != nil {
-		logrus.Errorf("Unable to set new instance: %v", err)
 		return nil, err
 	}
 	return newInstance, nil

--- a/k8s/operator/operator.go
+++ b/k8s/operator/operator.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	ostclientset "github.com/libopenstorage/operator/pkg/client/clientset/versioned"
-	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -65,7 +64,6 @@ func NewInstanceFromConfigFile(config string) (Ops, error) {
 	newInstance := &Client{}
 	err := newInstance.loadClientFromKubeconfig(config)
 	if err != nil {
-		logrus.Errorf("Unable to set new instance: %v", err)
 		return nil, err
 	}
 	return newInstance, nil

--- a/k8s/operator/operator.go
+++ b/k8s/operator/operator.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	ostclientset "github.com/libopenstorage/operator/pkg/client/clientset/versioned"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -56,6 +57,18 @@ func NewForConfig(c *rest.Config) (*Client, error) {
 	return &Client{
 		ost: ostClient,
 	}, nil
+}
+
+// NewInstanceFromConfigFile returns new instance of client by using given
+// config file
+func NewInstanceFromConfigFile(config string) (Ops, error) {
+	newInstance := &Client{}
+	err := newInstance.loadClientFromKubeconfig(config)
+	if err != nil {
+		logrus.Errorf("Unable to set new instance: %v", err)
+		return nil, err
+	}
+	return newInstance, nil
 }
 
 // Client is a wrapper for the operator client.

--- a/k8s/prometheus/prometheus.go
+++ b/k8s/prometheus/prometheus.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	prometheusclient "github.com/coreos/prometheus-operator/pkg/client/versioned"
-	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -68,7 +67,6 @@ func NewInstanceFromConfigFile(config string) (Ops, error) {
 	newInstance := &Client{}
 	err := newInstance.loadClientFromKubeconfig(config)
 	if err != nil {
-		logrus.Errorf("Unable to set new instance: %v", err)
 		return nil, err
 	}
 	return newInstance, nil

--- a/k8s/prometheus/prometheus.go
+++ b/k8s/prometheus/prometheus.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	prometheusclient "github.com/coreos/prometheus-operator/pkg/client/versioned"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -59,6 +60,18 @@ func NewForConfig(c *rest.Config) (*Client, error) {
 	return &Client{
 		prometheus: client,
 	}, nil
+}
+
+// NewInstanceFromConfigFile returns new instance of client by using given
+// config file
+func NewInstanceFromConfigFile(config string) (Ops, error) {
+	newInstance := &Client{}
+	err := newInstance.loadClientFromKubeconfig(config)
+	if err != nil {
+		logrus.Errorf("Unable to set new instance: %v", err)
+		return nil, err
+	}
+	return newInstance, nil
 }
 
 // Client is a wrapper for the prometheus operator client.

--- a/k8s/rbac/rbac.go
+++ b/k8s/rbac/rbac.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"sync"
 
-	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	"k8s.io/client-go/rest"
@@ -68,7 +67,6 @@ func NewInstanceFromConfigFile(config string) (Ops, error) {
 	newInstance := &Client{}
 	err := newInstance.loadClientFromKubeconfig(config)
 	if err != nil {
-		logrus.Errorf("Unable to set new instance: %v", err)
 		return nil, err
 	}
 	return newInstance, nil

--- a/k8s/rbac/rbac.go
+++ b/k8s/rbac/rbac.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	"k8s.io/client-go/rest"
@@ -59,6 +60,18 @@ func NewForConfig(c *rest.Config) (*Client, error) {
 	return &Client{
 		rbac: rbac,
 	}, nil
+}
+
+// NewInstanceFromConfigFile returns new instance of client by using given
+// config file
+func NewInstanceFromConfigFile(config string) (Ops, error) {
+	newInstance := &Client{}
+	err := newInstance.loadClientFromKubeconfig(config)
+	if err != nil {
+		logrus.Errorf("Unable to set new instance: %v", err)
+		return nil, err
+	}
+	return newInstance, nil
 }
 
 // Client is a wrapper for the kubernetes rbac client.

--- a/k8s/storage/storage.go
+++ b/k8s/storage/storage.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/sirupsen/logrus"
 	storagev1client "k8s.io/client-go/kubernetes/typed/storage/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -54,6 +55,18 @@ func NewForConfig(c *rest.Config) (*Client, error) {
 	return &Client{
 		storage: storage,
 	}, nil
+}
+
+// NewInstanceFromConfigFile returns new instance of client by using given
+// config file
+func NewInstanceFromConfigFile(config string) (Ops, error) {
+	newInstance := &Client{}
+	err := newInstance.loadClientFromKubeconfig(config)
+	if err != nil {
+		logrus.Errorf("Unable to set new instance: %v", err)
+		return nil, err
+	}
+	return newInstance, nil
 }
 
 // Client is a wrapper for the kubernetes storage client.

--- a/k8s/storage/storage.go
+++ b/k8s/storage/storage.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"sync"
 
-	"github.com/sirupsen/logrus"
 	storagev1client "k8s.io/client-go/kubernetes/typed/storage/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -63,7 +62,6 @@ func NewInstanceFromConfigFile(config string) (Ops, error) {
 	newInstance := &Client{}
 	err := newInstance.loadClientFromKubeconfig(config)
 	if err != nil {
-		logrus.Errorf("Unable to set new instance: %v", err)
 		return nil, err
 	}
 	return newInstance, nil

--- a/k8s/stork/stork.go
+++ b/k8s/stork/stork.go
@@ -7,7 +7,6 @@ import (
 
 	snapclient "github.com/kubernetes-incubator/external-storage/snapshot/pkg/client"
 	storkclientset "github.com/libopenstorage/stork/pkg/client/clientset/versioned"
-	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -85,7 +84,6 @@ func NewInstanceFromConfigFile(config string) (Ops, error) {
 	newInstance := &Client{}
 	err := newInstance.loadClientFromKubeconfig(config)
 	if err != nil {
-		logrus.Errorf("Unable to set new instance: %v", err)
 		return nil, err
 	}
 	return newInstance, nil

--- a/k8s/stork/stork.go
+++ b/k8s/stork/stork.go
@@ -7,6 +7,7 @@ import (
 
 	snapclient "github.com/kubernetes-incubator/external-storage/snapshot/pkg/client"
 	storkclientset "github.com/libopenstorage/stork/pkg/client/clientset/versioned"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -76,6 +77,18 @@ func NewForConfig(c *rest.Config) (*Client, error) {
 		kube:  kclient,
 		stork: storkClient,
 	}, nil
+}
+
+// NewInstanceFromConfigFile returns new instance of client by using given
+// config file
+func NewInstanceFromConfigFile(config string) (Ops, error) {
+	newInstance := &Client{}
+	err := newInstance.loadClientFromKubeconfig(config)
+	if err != nil {
+		logrus.Errorf("Unable to set new instance: %v", err)
+		return nil, err
+	}
+	return newInstance, nil
 }
 
 // Client is a wrapper for the stork operator client.

--- a/k8s/talisman/talisman.go
+++ b/k8s/talisman/talisman.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	talismanclientset "github.com/portworx/talisman/pkg/client/clientset/versioned"
-	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -65,7 +64,6 @@ func NewInstanceFromConfigFile(config string) (Ops, error) {
 	newInstance := &Client{}
 	err := newInstance.loadClientFromKubeconfig(config)
 	if err != nil {
-		logrus.Errorf("Unable to set new instance: %v", err)
 		return nil, err
 	}
 	return newInstance, nil

--- a/k8s/talisman/talisman.go
+++ b/k8s/talisman/talisman.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	talismanclientset "github.com/portworx/talisman/pkg/client/clientset/versioned"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -56,6 +57,18 @@ func NewForConfig(c *rest.Config) (*Client, error) {
 	return &Client{
 		talisman: talismanClient,
 	}, nil
+}
+
+// NewInstanceFromConfigFile returns new instance of client by using given
+// config file
+func NewInstanceFromConfigFile(config string) (Ops, error) {
+	newInstance := &Client{}
+	err := newInstance.loadClientFromKubeconfig(config)
+	if err != nil {
+		logrus.Errorf("Unable to set new instance: %v", err)
+		return nil, err
+	}
+	return newInstance, nil
 }
 
 // Client is a wrapper for the talisman operator client.


### PR DESCRIPTION
Adding NewInstanceFromConfigFile api to return a new instance from given Kubeconfig file. This is needed for torpedo and px-backup.