### PR TITLE
PTX-2279 fix mapToCSV to return empty when labelSelectors var is nil

### DIFF
--- a/k8s/core/util.go
+++ b/k8s/core/util.go
@@ -10,6 +10,9 @@ import (
 )
 
 func mapToCSV(in map[string]string) string {
+	if len(in) == 0 {
+		return ""
+	}
 	return labels.FormatLabels(in)
 }
 


### PR DESCRIPTION
Signed-off-by: Thiago Gonzaga <thi_gonzaga@yahoo.com.br>

this PR is required because `labels.FormatLabels(in)` returns `<none>` when `in` is `nil`  which is an invalid label causing sched-ops to fail with 
```
found '<', expected: !, identifier, or 'end of string'
```

Refer to: https://github.com/kubernetes/apimachinery/blob/master/pkg/labels/labels.go

this bug was introduced in #173 when replacing the old https://github.com/portworx/sched-ops/blob/42fb840b82eae5a66888ea90b450107579d129f5/k8s/util.go#L12-L19 to `labels.FormatLabels(in)`

