### PR TITLE
Ensure openshift client initialization

### DIFF
--- a/k8s/openshift/securitycontextconstraints.go
+++ b/k8s/openshift/securitycontextconstraints.go
@@ -22,15 +22,24 @@ func (c *Client) getOcpSecurityClient() ocpsecurityv1client.SecurityV1Interface 
 
 // ListSecurityContextConstraints returns the list of all SecurityContextConstraints, and an error if there is any.
 func (c *Client) ListSecurityContextConstraints() (result *ocpsecurityv1api.SecurityContextConstraintsList, err error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
 	return c.getOcpSecurityClient().SecurityContextConstraints().List(metav1.ListOptions{})
 }
 
 // GetSecurityContextConstraints takes name of the securityContextConstraints and returns the corresponding securityContextConstraints object, and an error if there is any.
 func (c *Client) GetSecurityContextConstraints(name string) (result *ocpsecurityv1api.SecurityContextConstraints, err error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
 	return c.getOcpSecurityClient().SecurityContextConstraints().Get(name, metav1.GetOptions{})
 }
 
 // UpdateSecurityContextConstraints takes the representation of a securityContextConstraints and updates it. Returns the server's representation of the securityContextConstraints, and an error, if there is any.
 func (c *Client) UpdateSecurityContextConstraints(securityContextConstraints *ocpsecurityv1api.SecurityContextConstraints) (result *ocpsecurityv1api.SecurityContextConstraints, err error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
 	return c.getOcpSecurityClient().SecurityContextConstraints().Update(securityContextConstraints)
 }


### PR DESCRIPTION
Usage of the openshift client could cause a panic:
```
Test Panicked
runtime error: invalid memory address or nil pointer dereference
/usr/local/go/src/runtime/panic.go:82   Full Stack Trace
   github.com/portworx/sched-ops/k8s/openshift.(*Client).getOcpSecurityClient(...)   	/go/src/github.com/portworx/torpedo/vendor/github.com/portworx/sched-ops/k8s/openshift/securitycontextconstraints.go:20
```

Add client initialization to SecurityContextConstraints methods to ensure client readiness.

Signed-off-by: Serhii Aheienko <serhii.aheienko@gmail.com>