### PR TITLE
Fix for DoRetryWithTimeout when no retry with error

### DIFF
--- a/task/task.go
+++ b/task/task.go
@@ -48,7 +48,7 @@ func DoRetryWithTimeout(t func() (interface{}, bool, error), timeout, timeBefore
 				return
 			default:
 				out, retry, err := t()
-				if err == nil || !retry {
+				if err == nil {
 					resultChan <- out
 					return
 				}


### PR DESCRIPTION
I'v noticed that if we use `return nil, false, err` in function which we pass to `DoRetryWithTimeout` it returns err as nil.

Signed-off-by: Maksym Borodin <maksym@portworx.com>