### PR TITLE
Use an explicit version of the stork client

### DIFF
--- a/k8s/stork/applicationbackuprestore.go
+++ b/k8s/stork/applicationbackuprestore.go
@@ -60,7 +60,7 @@ func (c *Client) CreateApplicationBackup(backup *storkv1alpha1.ApplicationBackup
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ApplicationBackups(backup.Namespace).Create(backup)
+	return c.stork.StorkV1alpha1().ApplicationBackups(backup.Namespace).Create(backup)
 }
 
 // GetApplicationBackup gets the ApplicationBackup
@@ -68,7 +68,7 @@ func (c *Client) GetApplicationBackup(name string, namespace string) (*storkv1al
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ApplicationBackups(namespace).Get(name, metav1.GetOptions{})
+	return c.stork.StorkV1alpha1().ApplicationBackups(namespace).Get(name, metav1.GetOptions{})
 }
 
 // ListApplicationBackups lists all the ApplicationBackups
@@ -76,7 +76,7 @@ func (c *Client) ListApplicationBackups(namespace string) (*storkv1alpha1.Applic
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ApplicationBackups(namespace).List(metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().ApplicationBackups(namespace).List(metav1.ListOptions{})
 }
 
 // DeleteApplicationBackup deletes the ApplicationBackup
@@ -84,7 +84,7 @@ func (c *Client) DeleteApplicationBackup(name string, namespace string) error {
 	if err := c.initClient(); err != nil {
 		return err
 	}
-	return c.stork.Stork().ApplicationBackups(namespace).Delete(name, &metav1.DeleteOptions{
+	return c.stork.StorkV1alpha1().ApplicationBackups(namespace).Delete(name, &metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
 }
@@ -94,7 +94,7 @@ func (c *Client) UpdateApplicationBackup(backup *storkv1alpha1.ApplicationBackup
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ApplicationBackups(backup.Namespace).Update(backup)
+	return c.stork.StorkV1alpha1().ApplicationBackups(backup.Namespace).Update(backup)
 }
 
 // ValidateApplicationBackup validates the ApplicationBackup
@@ -131,7 +131,7 @@ func (c *Client) GetApplicationRestore(name string, namespace string) (*storkv1a
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ApplicationRestores(namespace).Get(name, metav1.GetOptions{})
+	return c.stork.StorkV1alpha1().ApplicationRestores(namespace).Get(name, metav1.GetOptions{})
 }
 
 // ListApplicationRestores lists all the ApplicationRestores
@@ -139,7 +139,7 @@ func (c *Client) ListApplicationRestores(namespace string) (*storkv1alpha1.Appli
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ApplicationRestores(namespace).List(metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().ApplicationRestores(namespace).List(metav1.ListOptions{})
 }
 
 // CreateApplicationRestore creates the ApplicationRestore
@@ -147,7 +147,7 @@ func (c *Client) CreateApplicationRestore(restore *storkv1alpha1.ApplicationRest
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ApplicationRestores(restore.Namespace).Create(restore)
+	return c.stork.StorkV1alpha1().ApplicationRestores(restore.Namespace).Create(restore)
 }
 
 // DeleteApplicationRestore deletes the ApplicationRestore
@@ -155,7 +155,7 @@ func (c *Client) DeleteApplicationRestore(name string, namespace string) error {
 	if err := c.initClient(); err != nil {
 		return err
 	}
-	return c.stork.Stork().ApplicationRestores(namespace).Delete(name, &metav1.DeleteOptions{
+	return c.stork.StorkV1alpha1().ApplicationRestores(namespace).Delete(name, &metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
 }
@@ -166,7 +166,7 @@ func (c *Client) ValidateApplicationRestore(name, namespace string, timeout, ret
 		return err
 	}
 	t := func() (interface{}, bool, error) {
-		applicationrestore, err := c.stork.Stork().ApplicationRestores(namespace).Get(name, metav1.GetOptions{})
+		applicationrestore, err := c.stork.StorkV1alpha1().ApplicationRestores(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			return "", true, err
 		}
@@ -191,7 +191,7 @@ func (c *Client) UpdateApplicationRestore(restore *storkv1alpha1.ApplicationRest
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ApplicationRestores(restore.Namespace).Update(restore)
+	return c.stork.StorkV1alpha1().ApplicationRestores(restore.Namespace).Update(restore)
 }
 
 // GetApplicationBackupSchedule gets the ApplicationBackupSchedule
@@ -199,7 +199,7 @@ func (c *Client) GetApplicationBackupSchedule(name string, namespace string) (*s
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ApplicationBackupSchedules(namespace).Get(name, metav1.GetOptions{})
+	return c.stork.StorkV1alpha1().ApplicationBackupSchedules(namespace).Get(name, metav1.GetOptions{})
 }
 
 // ListApplicationBackupSchedules lists all the ApplicationBackupSchedules
@@ -207,7 +207,7 @@ func (c *Client) ListApplicationBackupSchedules(namespace string) (*storkv1alpha
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ApplicationBackupSchedules(namespace).List(metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().ApplicationBackupSchedules(namespace).List(metav1.ListOptions{})
 }
 
 // CreateApplicationBackupSchedule creates an ApplicationBackupSchedule
@@ -215,7 +215,7 @@ func (c *Client) CreateApplicationBackupSchedule(applicationBackupSchedule *stor
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ApplicationBackupSchedules(applicationBackupSchedule.Namespace).Create(applicationBackupSchedule)
+	return c.stork.StorkV1alpha1().ApplicationBackupSchedules(applicationBackupSchedule.Namespace).Create(applicationBackupSchedule)
 }
 
 // UpdateApplicationBackupSchedule updates the ApplicationBackupSchedule
@@ -223,7 +223,7 @@ func (c *Client) UpdateApplicationBackupSchedule(applicationBackupSchedule *stor
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ApplicationBackupSchedules(applicationBackupSchedule.Namespace).Update(applicationBackupSchedule)
+	return c.stork.StorkV1alpha1().ApplicationBackupSchedules(applicationBackupSchedule.Namespace).Update(applicationBackupSchedule)
 }
 
 // DeleteApplicationBackupSchedule deletes the ApplicationBackupSchedule
@@ -231,7 +231,7 @@ func (c *Client) DeleteApplicationBackupSchedule(name string, namespace string) 
 	if err := c.initClient(); err != nil {
 		return err
 	}
-	return c.stork.Stork().ApplicationBackupSchedules(namespace).Delete(name, &metav1.DeleteOptions{
+	return c.stork.StorkV1alpha1().ApplicationBackupSchedules(namespace).Delete(name, &metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
 }

--- a/k8s/stork/applicationclone.go
+++ b/k8s/stork/applicationclone.go
@@ -31,7 +31,7 @@ func (c *Client) CreateApplicationClone(clone *storkv1alpha1.ApplicationClone) (
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ApplicationClones(clone.Namespace).Create(clone)
+	return c.stork.StorkV1alpha1().ApplicationClones(clone.Namespace).Create(clone)
 }
 
 // GetApplicationClone gets the ApplicationClone
@@ -39,7 +39,7 @@ func (c *Client) GetApplicationClone(name string, namespace string) (*storkv1alp
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ApplicationClones(namespace).Get(name, metav1.GetOptions{})
+	return c.stork.StorkV1alpha1().ApplicationClones(namespace).Get(name, metav1.GetOptions{})
 }
 
 // ListApplicationClones lists all the ApplicationClones
@@ -47,7 +47,7 @@ func (c *Client) ListApplicationClones(namespace string) (*storkv1alpha1.Applica
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ApplicationClones(namespace).List(metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().ApplicationClones(namespace).List(metav1.ListOptions{})
 }
 
 // DeleteApplicationClone deletes the ApplicationClone
@@ -55,7 +55,7 @@ func (c *Client) DeleteApplicationClone(name string, namespace string) error {
 	if err := c.initClient(); err != nil {
 		return err
 	}
-	return c.stork.Stork().ApplicationClones(namespace).Delete(name, &metav1.DeleteOptions{
+	return c.stork.StorkV1alpha1().ApplicationClones(namespace).Delete(name, &metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
 }
@@ -65,7 +65,7 @@ func (c *Client) UpdateApplicationClone(clone *storkv1alpha1.ApplicationClone) (
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ApplicationClones(clone.Namespace).Update(clone)
+	return c.stork.StorkV1alpha1().ApplicationClones(clone.Namespace).Update(clone)
 }
 
 // ValidateApplicationClone validates the ApplicationClone
@@ -74,7 +74,7 @@ func (c *Client) ValidateApplicationClone(name, namespace string, timeout, retry
 		return err
 	}
 	t := func() (interface{}, bool, error) {
-		applicationclone, err := c.stork.Stork().ApplicationClones(namespace).Get(name, metav1.GetOptions{})
+		applicationclone, err := c.stork.StorkV1alpha1().ApplicationClones(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			return "", true, err
 		}

--- a/k8s/stork/backuplocation.go
+++ b/k8s/stork/backuplocation.go
@@ -31,7 +31,7 @@ func (c *Client) CreateBackupLocation(backupLocation *storkv1alpha1.BackupLocati
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().BackupLocations(backupLocation.Namespace).Create(backupLocation)
+	return c.stork.StorkV1alpha1().BackupLocations(backupLocation.Namespace).Create(backupLocation)
 }
 
 // GetBackupLocation gets the BackupLocation
@@ -39,7 +39,7 @@ func (c *Client) GetBackupLocation(name string, namespace string) (*storkv1alpha
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	backupLocation, err := c.stork.Stork().BackupLocations(namespace).Get(name, metav1.GetOptions{})
+	backupLocation, err := c.stork.StorkV1alpha1().BackupLocations(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (c *Client) ListBackupLocations(namespace string) (*storkv1alpha1.BackupLoc
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	backupLocations, err := c.stork.Stork().BackupLocations(namespace).List(metav1.ListOptions{})
+	backupLocations, err := c.stork.StorkV1alpha1().BackupLocations(namespace).List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (c *Client) UpdateBackupLocation(backupLocation *storkv1alpha1.BackupLocati
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().BackupLocations(backupLocation.Namespace).Update(backupLocation)
+	return c.stork.StorkV1alpha1().BackupLocations(backupLocation.Namespace).Update(backupLocation)
 }
 
 // DeleteBackupLocation deletes the BackupLocation
@@ -83,7 +83,7 @@ func (c *Client) DeleteBackupLocation(name string, namespace string) error {
 	if err := c.initClient(); err != nil {
 		return err
 	}
-	return c.stork.Stork().BackupLocations(namespace).Delete(name, &metav1.DeleteOptions{
+	return c.stork.StorkV1alpha1().BackupLocations(namespace).Delete(name, &metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
 }

--- a/k8s/stork/clusterdomains.go
+++ b/k8s/stork/clusterdomains.go
@@ -43,7 +43,7 @@ func (c *Client) CreateClusterDomainsStatus(clusterDomainsStatus *storkv1alpha1.
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ClusterDomainsStatuses().Create(clusterDomainsStatus)
+	return c.stork.StorkV1alpha1().ClusterDomainsStatuses().Create(clusterDomainsStatus)
 }
 
 // GetClusterDomainsStatus gets the ClusterDomainsStatus
@@ -51,7 +51,7 @@ func (c *Client) GetClusterDomainsStatus(name string) (*storkv1alpha1.ClusterDom
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ClusterDomainsStatuses().Get(name, metav1.GetOptions{})
+	return c.stork.StorkV1alpha1().ClusterDomainsStatuses().Get(name, metav1.GetOptions{})
 }
 
 // UpdateClusterDomainsStatus updates the ClusterDomainsStatus
@@ -59,7 +59,7 @@ func (c *Client) UpdateClusterDomainsStatus(clusterDomainsStatus *storkv1alpha1.
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ClusterDomainsStatuses().Update(clusterDomainsStatus)
+	return c.stork.StorkV1alpha1().ClusterDomainsStatuses().Update(clusterDomainsStatus)
 }
 
 // DeleteClusterDomainsStatus deletes the ClusterDomainsStatus
@@ -67,7 +67,7 @@ func (c *Client) DeleteClusterDomainsStatus(name string) error {
 	if err := c.initClient(); err != nil {
 		return err
 	}
-	return c.stork.Stork().ClusterDomainsStatuses().Delete(name, &metav1.DeleteOptions{
+	return c.stork.StorkV1alpha1().ClusterDomainsStatuses().Delete(name, &metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
 }
@@ -122,7 +122,7 @@ func (c *Client) ListClusterDomainStatuses() (*storkv1alpha1.ClusterDomainsStatu
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ClusterDomainsStatuses().List(metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().ClusterDomainsStatuses().List(metav1.ListOptions{})
 }
 
 // CreateClusterDomainUpdate creates the ClusterDomainUpdate
@@ -130,7 +130,7 @@ func (c *Client) CreateClusterDomainUpdate(clusterDomainUpdate *storkv1alpha1.Cl
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ClusterDomainUpdates().Create(clusterDomainUpdate)
+	return c.stork.StorkV1alpha1().ClusterDomainUpdates().Create(clusterDomainUpdate)
 }
 
 // GetClusterDomainUpdate gets the ClusterDomainUpdate
@@ -138,7 +138,7 @@ func (c *Client) GetClusterDomainUpdate(name string) (*storkv1alpha1.ClusterDoma
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ClusterDomainUpdates().Get(name, metav1.GetOptions{})
+	return c.stork.StorkV1alpha1().ClusterDomainUpdates().Get(name, metav1.GetOptions{})
 }
 
 // UpdateClusterDomainUpdate updates the ClusterDomainUpdate
@@ -146,7 +146,7 @@ func (c *Client) UpdateClusterDomainUpdate(clusterDomainUpdate *storkv1alpha1.Cl
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ClusterDomainUpdates().Update(clusterDomainUpdate)
+	return c.stork.StorkV1alpha1().ClusterDomainUpdates().Update(clusterDomainUpdate)
 }
 
 // DeleteClusterDomainUpdate deletes the ClusterDomainUpdate
@@ -154,7 +154,7 @@ func (c *Client) DeleteClusterDomainUpdate(name string) error {
 	if err := c.initClient(); err != nil {
 		return err
 	}
-	return c.stork.Stork().ClusterDomainUpdates().Delete(name, &metav1.DeleteOptions{
+	return c.stork.StorkV1alpha1().ClusterDomainUpdates().Delete(name, &metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
 }
@@ -198,5 +198,5 @@ func (c *Client) ListClusterDomainUpdates() (*storkv1alpha1.ClusterDomainUpdateL
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ClusterDomainUpdates().List(metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().ClusterDomainUpdates().List(metav1.ListOptions{})
 }

--- a/k8s/stork/clusterpair.go
+++ b/k8s/stork/clusterpair.go
@@ -31,7 +31,7 @@ func (c *Client) CreateClusterPair(pair *storkv1alpha1.ClusterPair) (*storkv1alp
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ClusterPairs(pair.Namespace).Create(pair)
+	return c.stork.StorkV1alpha1().ClusterPairs(pair.Namespace).Create(pair)
 }
 
 // GetClusterPair gets the ClusterPair
@@ -39,7 +39,7 @@ func (c *Client) GetClusterPair(name string, namespace string) (*storkv1alpha1.C
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ClusterPairs(namespace).Get(name, metav1.GetOptions{})
+	return c.stork.StorkV1alpha1().ClusterPairs(namespace).Get(name, metav1.GetOptions{})
 }
 
 // ListClusterPairs gets all the ClusterPairs
@@ -47,7 +47,7 @@ func (c *Client) ListClusterPairs(namespace string) (*storkv1alpha1.ClusterPairL
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ClusterPairs(namespace).List(metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().ClusterPairs(namespace).List(metav1.ListOptions{})
 }
 
 // UpdateClusterPair updates the ClusterPair
@@ -55,7 +55,7 @@ func (c *Client) UpdateClusterPair(pair *storkv1alpha1.ClusterPair) (*storkv1alp
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().ClusterPairs(pair.Namespace).Update(pair)
+	return c.stork.StorkV1alpha1().ClusterPairs(pair.Namespace).Update(pair)
 }
 
 // DeleteClusterPair deletes the ClusterPair
@@ -63,7 +63,7 @@ func (c *Client) DeleteClusterPair(name string, namespace string) error {
 	if err := c.initClient(); err != nil {
 		return err
 	}
-	return c.stork.Stork().ClusterPairs(namespace).Delete(name, &metav1.DeleteOptions{
+	return c.stork.StorkV1alpha1().ClusterPairs(namespace).Delete(name, &metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
 }

--- a/k8s/stork/groupsnapshot.go
+++ b/k8s/stork/groupsnapshot.go
@@ -36,7 +36,7 @@ func (c *Client) GetGroupSnapshot(name, namespace string) (*storkv1alpha1.GroupV
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().GroupVolumeSnapshots(namespace).Get(name, metav1.GetOptions{})
+	return c.stork.StorkV1alpha1().GroupVolumeSnapshots(namespace).Get(name, metav1.GetOptions{})
 }
 
 // ListGroupSnapshots lists all group snapshots for the given namespace
@@ -44,7 +44,7 @@ func (c *Client) ListGroupSnapshots(namespace string) (*storkv1alpha1.GroupVolum
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().GroupVolumeSnapshots(namespace).List(metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().GroupVolumeSnapshots(namespace).List(metav1.ListOptions{})
 }
 
 // CreateGroupSnapshot creates the given group snapshot
@@ -52,12 +52,12 @@ func (c *Client) CreateGroupSnapshot(snap *storkv1alpha1.GroupVolumeSnapshot) (*
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().GroupVolumeSnapshots(snap.Namespace).Create(snap)
+	return c.stork.StorkV1alpha1().GroupVolumeSnapshots(snap.Namespace).Create(snap)
 }
 
 // UpdateGroupSnapshot updates the given group snapshot
 func (c *Client) UpdateGroupSnapshot(snap *storkv1alpha1.GroupVolumeSnapshot) (*storkv1alpha1.GroupVolumeSnapshot, error) {
-	return c.stork.Stork().GroupVolumeSnapshots(snap.Namespace).Update(snap)
+	return c.stork.StorkV1alpha1().GroupVolumeSnapshots(snap.Namespace).Update(snap)
 }
 
 // DeleteGroupSnapshot deletes the group snapshot with the given name and namespace
@@ -65,7 +65,7 @@ func (c *Client) DeleteGroupSnapshot(name, namespace string) error {
 	if err := c.initClient(); err != nil {
 		return err
 	}
-	return c.stork.Stork().GroupVolumeSnapshots(namespace).Delete(name, &metav1.DeleteOptions{
+	return c.stork.StorkV1alpha1().GroupVolumeSnapshots(namespace).Delete(name, &metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
 }

--- a/k8s/stork/migration.go
+++ b/k8s/stork/migration.go
@@ -47,7 +47,7 @@ func (c *Client) GetMigration(name string, namespace string) (*storkv1alpha1.Mig
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().Migrations(namespace).Get(name, metav1.GetOptions{})
+	return c.stork.StorkV1alpha1().Migrations(namespace).Get(name, metav1.GetOptions{})
 }
 
 // ListMigrations lists all the Migrations
@@ -55,7 +55,7 @@ func (c *Client) ListMigrations(namespace string) (*storkv1alpha1.MigrationList,
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().Migrations(namespace).List(metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().Migrations(namespace).List(metav1.ListOptions{})
 }
 
 // CreateMigration creates the Migration
@@ -63,7 +63,7 @@ func (c *Client) CreateMigration(migration *storkv1alpha1.Migration) (*storkv1al
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().Migrations(migration.Namespace).Create(migration)
+	return c.stork.StorkV1alpha1().Migrations(migration.Namespace).Create(migration)
 }
 
 // DeleteMigration deletes the Migration
@@ -71,7 +71,7 @@ func (c *Client) DeleteMigration(name string, namespace string) error {
 	if err := c.initClient(); err != nil {
 		return err
 	}
-	return c.stork.Stork().Migrations(namespace).Delete(name, &metav1.DeleteOptions{
+	return c.stork.StorkV1alpha1().Migrations(namespace).Delete(name, &metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
 }
@@ -81,7 +81,7 @@ func (c *Client) UpdateMigration(migration *storkv1alpha1.Migration) (*storkv1al
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().Migrations(migration.Namespace).Update(migration)
+	return c.stork.StorkV1alpha1().Migrations(migration.Namespace).Update(migration)
 }
 
 // ValidateMigration validate the Migration status
@@ -124,7 +124,7 @@ func (c *Client) GetMigrationSchedule(name string, namespace string) (*storkv1al
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().MigrationSchedules(namespace).Get(name, metav1.GetOptions{})
+	return c.stork.StorkV1alpha1().MigrationSchedules(namespace).Get(name, metav1.GetOptions{})
 }
 
 // ListMigrationSchedules lists all the MigrationSchedules
@@ -132,7 +132,7 @@ func (c *Client) ListMigrationSchedules(namespace string) (*storkv1alpha1.Migrat
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().MigrationSchedules(namespace).List(metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().MigrationSchedules(namespace).List(metav1.ListOptions{})
 }
 
 // CreateMigrationSchedule creates a MigrationSchedule
@@ -140,7 +140,7 @@ func (c *Client) CreateMigrationSchedule(migrationSchedule *storkv1alpha1.Migrat
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().MigrationSchedules(migrationSchedule.Namespace).Create(migrationSchedule)
+	return c.stork.StorkV1alpha1().MigrationSchedules(migrationSchedule.Namespace).Create(migrationSchedule)
 }
 
 // UpdateMigrationSchedule updates the MigrationSchedule
@@ -148,7 +148,7 @@ func (c *Client) UpdateMigrationSchedule(migrationSchedule *storkv1alpha1.Migrat
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().MigrationSchedules(migrationSchedule.Namespace).Update(migrationSchedule)
+	return c.stork.StorkV1alpha1().MigrationSchedules(migrationSchedule.Namespace).Update(migrationSchedule)
 }
 
 // DeleteMigrationSchedule deletes the MigrationSchedule
@@ -156,7 +156,7 @@ func (c *Client) DeleteMigrationSchedule(name string, namespace string) error {
 	if err := c.initClient(); err != nil {
 		return err
 	}
-	return c.stork.Stork().MigrationSchedules(namespace).Delete(name, &metav1.DeleteOptions{
+	return c.stork.StorkV1alpha1().MigrationSchedules(namespace).Delete(name, &metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
 }

--- a/k8s/stork/rule.go
+++ b/k8s/stork/rule.go
@@ -20,7 +20,7 @@ func (c *Client) GetRule(name, namespace string) (*storkv1alpha1.Rule, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().Rules(namespace).Get(name, metav1.GetOptions{})
+	return c.stork.StorkV1alpha1().Rules(namespace).Get(name, metav1.GetOptions{})
 }
 
 // CreateRule creates the given stork rule
@@ -28,7 +28,7 @@ func (c *Client) CreateRule(rule *storkv1alpha1.Rule) (*storkv1alpha1.Rule, erro
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().Rules(rule.GetNamespace()).Create(rule)
+	return c.stork.StorkV1alpha1().Rules(rule.GetNamespace()).Create(rule)
 }
 
 // DeleteRule deletes the given stork rule
@@ -36,7 +36,7 @@ func (c *Client) DeleteRule(name, namespace string) error {
 	if err := c.initClient(); err != nil {
 		return err
 	}
-	return c.stork.Stork().Rules(namespace).Delete(name, &metav1.DeleteOptions{
+	return c.stork.StorkV1alpha1().Rules(namespace).Delete(name, &metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
 }

--- a/k8s/stork/schedulepolicy.go
+++ b/k8s/stork/schedulepolicy.go
@@ -24,7 +24,7 @@ func (c *Client) CreateSchedulePolicy(schedulePolicy *storkv1alpha1.SchedulePoli
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().SchedulePolicies().Create(schedulePolicy)
+	return c.stork.StorkV1alpha1().SchedulePolicies().Create(schedulePolicy)
 }
 
 // GetSchedulePolicy gets the SchedulePolicy
@@ -32,7 +32,7 @@ func (c *Client) GetSchedulePolicy(name string) (*storkv1alpha1.SchedulePolicy, 
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().SchedulePolicies().Get(name, metav1.GetOptions{})
+	return c.stork.StorkV1alpha1().SchedulePolicies().Get(name, metav1.GetOptions{})
 }
 
 // ListSchedulePolicies lists all the SchedulePolicies
@@ -40,7 +40,7 @@ func (c *Client) ListSchedulePolicies() (*storkv1alpha1.SchedulePolicyList, erro
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().SchedulePolicies().List(metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().SchedulePolicies().List(metav1.ListOptions{})
 }
 
 // UpdateSchedulePolicy updates the SchedulePolicy
@@ -48,7 +48,7 @@ func (c *Client) UpdateSchedulePolicy(schedulePolicy *storkv1alpha1.SchedulePoli
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().SchedulePolicies().Update(schedulePolicy)
+	return c.stork.StorkV1alpha1().SchedulePolicies().Update(schedulePolicy)
 }
 
 // DeleteSchedulePolicy deletes the SchedulePolicy
@@ -56,7 +56,7 @@ func (c *Client) DeleteSchedulePolicy(name string) error {
 	if err := c.initClient(); err != nil {
 		return err
 	}
-	return c.stork.Stork().SchedulePolicies().Delete(name, &metav1.DeleteOptions{
+	return c.stork.StorkV1alpha1().SchedulePolicies().Delete(name, &metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
 }

--- a/k8s/stork/snapshotschedule.go
+++ b/k8s/stork/snapshotschedule.go
@@ -36,7 +36,7 @@ func (c *Client) CreateSnapshotSchedule(snapshotSchedule *storkv1alpha1.VolumeSn
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().VolumeSnapshotSchedules(snapshotSchedule.Namespace).Create(snapshotSchedule)
+	return c.stork.StorkV1alpha1().VolumeSnapshotSchedules(snapshotSchedule.Namespace).Create(snapshotSchedule)
 }
 
 // GetSnapshotSchedule gets the SnapshotSchedule
@@ -44,7 +44,7 @@ func (c *Client) GetSnapshotSchedule(name string, namespace string) (*storkv1alp
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().VolumeSnapshotSchedules(namespace).Get(name, metav1.GetOptions{})
+	return c.stork.StorkV1alpha1().VolumeSnapshotSchedules(namespace).Get(name, metav1.GetOptions{})
 }
 
 // ListSnapshotSchedules lists all the SnapshotSchedules
@@ -52,7 +52,7 @@ func (c *Client) ListSnapshotSchedules(namespace string) (*storkv1alpha1.VolumeS
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().VolumeSnapshotSchedules(namespace).List(metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().VolumeSnapshotSchedules(namespace).List(metav1.ListOptions{})
 }
 
 // UpdateSnapshotSchedule updates the SnapshotSchedule
@@ -60,7 +60,7 @@ func (c *Client) UpdateSnapshotSchedule(snapshotSchedule *storkv1alpha1.VolumeSn
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().VolumeSnapshotSchedules(snapshotSchedule.Namespace).Update(snapshotSchedule)
+	return c.stork.StorkV1alpha1().VolumeSnapshotSchedules(snapshotSchedule.Namespace).Update(snapshotSchedule)
 }
 
 // DeleteSnapshotSchedule deletes the SnapshotSchedule
@@ -68,7 +68,7 @@ func (c *Client) DeleteSnapshotSchedule(name string, namespace string) error {
 	if err := c.initClient(); err != nil {
 		return err
 	}
-	return c.stork.Stork().VolumeSnapshotSchedules(namespace).Delete(name, &metav1.DeleteOptions{
+	return c.stork.StorkV1alpha1().VolumeSnapshotSchedules(namespace).Delete(name, &metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
 }

--- a/k8s/stork/volumesnapshot.go
+++ b/k8s/stork/volumesnapshot.go
@@ -33,7 +33,7 @@ func (c *Client) CreateVolumeSnapshotRestore(snapRestore *storkv1alpha1.VolumeSn
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().VolumeSnapshotRestores(snapRestore.Namespace).Create(snapRestore)
+	return c.stork.StorkV1alpha1().VolumeSnapshotRestores(snapRestore.Namespace).Create(snapRestore)
 }
 
 // UpdateVolumeSnapshotRestore updates given volumesnapshorestore CRD
@@ -41,7 +41,7 @@ func (c *Client) UpdateVolumeSnapshotRestore(snapRestore *storkv1alpha1.VolumeSn
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().VolumeSnapshotRestores(snapRestore.Namespace).Update(snapRestore)
+	return c.stork.StorkV1alpha1().VolumeSnapshotRestores(snapRestore.Namespace).Update(snapRestore)
 }
 
 // GetVolumeSnapshotRestore returns details of given restore crd status
@@ -49,7 +49,7 @@ func (c *Client) GetVolumeSnapshotRestore(name, namespace string) (*storkv1alpha
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().VolumeSnapshotRestores(namespace).Get(name, metav1.GetOptions{})
+	return c.stork.StorkV1alpha1().VolumeSnapshotRestores(namespace).Get(name, metav1.GetOptions{})
 }
 
 // ListVolumeSnapshotRestore return list of volumesnapshotrestores in given namespaces
@@ -57,7 +57,7 @@ func (c *Client) ListVolumeSnapshotRestore(namespace string) (*storkv1alpha1.Vol
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.Stork().VolumeSnapshotRestores(namespace).List(metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().VolumeSnapshotRestores(namespace).List(metav1.ListOptions{})
 }
 
 // DeleteVolumeSnapshotRestore delete given volumesnapshotrestore CRD
@@ -65,7 +65,7 @@ func (c *Client) DeleteVolumeSnapshotRestore(name, namespace string) error {
 	if err := c.initClient(); err != nil {
 		return err
 	}
-	return c.stork.Stork().VolumeSnapshotRestores(namespace).Delete(name, &metav1.DeleteOptions{})
+	return c.stork.StorkV1alpha1().VolumeSnapshotRestores(namespace).Delete(name, &metav1.DeleteOptions{})
 }
 
 // ValidateVolumeSnapshotRestore validates given volumesnapshotrestore CRD
@@ -74,7 +74,7 @@ func (c *Client) ValidateVolumeSnapshotRestore(name, namespace string, timeout, 
 		return err
 	}
 	t := func() (interface{}, bool, error) {
-		snapRestore, err := c.stork.Stork().VolumeSnapshotRestores(namespace).Get(name, metav1.GetOptions{})
+		snapRestore, err := c.stork.StorkV1alpha1().VolumeSnapshotRestores(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			return "", true, err
 		}


### PR DESCRIPTION
```
// Deprecated: please explicitly pick a version if possible.
Stork() storkv1alpha1.StorkV1alpha1Interface
```
Use StorkV1Alpha1() instead of Stork() one.

Signed-off-by: Serhii Aheienko <serhii.aheienko@gmail.com>