### PR TITLE
fix a nil pointer while finding replicaset by deployment

### DIFF
--- a/k8s/apps/deployments.go
+++ b/k8s/apps/deployments.go
@@ -211,6 +211,9 @@ func (c *Client) ValidateTerminatedDeployment(deployment *appsv1.Deployment, tim
 
 		pods, err := c.GetDeploymentPods(deployment)
 		if err != nil {
+			if errors.IsNotFound(err) {
+				return "", false, nil
+			}
 			return "", true, &schederrors.ErrAppNotTerminated{
 				ID:    dep.Name,
 				Cause: fmt.Sprintf("Failed to get pods for deployment. Err: %v", err),

--- a/k8s/apps/replicasets.go
+++ b/k8s/apps/replicasets.go
@@ -9,7 +9,9 @@ import (
 	"github.com/portworx/sched-ops/task"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // ReplicaSetOps is an interface to perform k8s daemon set operations
@@ -181,7 +183,7 @@ func (c *Client) DeleteReplicaSet(name, namespace string) error {
 		&metav1.DeleteOptions{PropagationPolicy: &deleteForegroundPolicy})
 }
 
-// GetReplicaSetByDeployment get ReplicaSet for a Given Deployemnt
+// GetReplicaSetByDeployment get ReplicaSet for a Given Deployment
 func (c *Client) GetReplicaSetByDeployment(deployment *appsv1.Deployment) (*appsv1.ReplicaSet, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
@@ -198,5 +200,8 @@ func (c *Client) GetReplicaSetByDeployment(deployment *appsv1.Deployment) (*apps
 			}
 		}
 	}
-	return nil, nil
+	return nil, errors.NewNotFound(schema.GroupResource{
+		Group:    "apps",
+		Resource: "replicasets",
+	}, deployment.Name)
 }


### PR DESCRIPTION
fix a bug introduced in #219 when replicaset is not found for a given deployment during ValidateTermination, this issue happens when replicaset gets deleted right after we retrieve the deployment spec.

Signed-off-by: Thiago Gonzaga <thi_gonzaga@yahoo.com.br>