### PR TITLE
Get the latest deployment before validating the replica sets

### DIFF
--- a/k8s/apps/replicasets.go
+++ b/k8s/apps/replicasets.go
@@ -186,10 +186,14 @@ func (c *Client) DeleteReplicaSet(name, namespace string) error {
 
 // GetReplicaSetByDeployment get ReplicaSet for a Given Deployment
 func (c *Client) GetReplicaSetByDeployment(deployment *appsv1.Deployment) (*appsv1.ReplicaSet, error) {
+	dep, err := c.GetDeployment(deployment.Name, deployment.Namespace)
+	if err != nil {
+		return nil, err
+	}
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	rsets, err := c.apps.ReplicaSets(deployment.Namespace).List(context.TODO(), metav1.ListOptions{})
+	rsets, err := c.apps.ReplicaSets(dep.Namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +201,7 @@ func (c *Client) GetReplicaSetByDeployment(deployment *appsv1.Deployment) (*apps
 	revisionAnnotation := "deployment.kubernetes.io/revision"
 	for _, rs := range rsets.Items {
 		for _, ownerReference := range rs.OwnerReferences {
-			if ownerReference.Name == deployment.Name && deployment.Annotations[revisionAnnotation] == rs.Annotations[revisionAnnotation] {
+			if ownerReference.Name == dep.Name && dep.Annotations[revisionAnnotation] == rs.Annotations[revisionAnnotation] {
 				return &rs, nil
 			}
 		}


### PR DESCRIPTION
Why do we need this PR?
* Currently, in the `GetReplicaSetByDeployment` method we do not do a "Get" on the latest deployment.
* So we use a `stale` copy of the deployment object causing the check on the deployment annotations to fail.
* This change will add a "Get" on the deployment object at the beginning of the method

Signed-off-by: Rohit-PX <rohit@portworx.com>