### PR TITLE
PTX-3253 Add check for controlplane label to determine master node

### DIFF
--- a/k8s/core/core.go
+++ b/k8s/core/core.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	masterLabelKey           = "node-role.kubernetes.io/master"
+	controlplaneLabelKey     = "node-role.kubernetes.io/controlplane"
 	pvcStorageProvisionerKey = "volume.beta.kubernetes.io/storage-provisioner"
 	labelUpdateMaxRetries    = 5
 )

--- a/k8s/core/nodes.go
+++ b/k8s/core/nodes.go
@@ -135,8 +135,10 @@ func (c *Client) IsNodeReady(name string) error {
 
 // IsNodeMaster returns true if given node is a kubernetes master node
 func (c *Client) IsNodeMaster(node corev1.Node) bool {
-	_, ok := node.Labels[masterLabelKey]
-	return ok
+	if len(node.Labels[masterLabelKey]) > 0 || len(node.Labels[controlplaneLabelKey]) > 0 {
+		return true
+	}
+	return false
 }
 
 // GetLabelsOnNode gets all the labels on the given node


### PR DESCRIPTION
Right now we only checking for "node-role.kubernetes.io/master", Rancher master node doesn't have this label. Rancher Master node has a different label called "node-role.kubernetes.io/controlplane". Need to add check for this as well.
