### PR TITLE
pb-1890: Add the BackupLocationMaintenanceOps to be part of kdmp Ops interface.

### DIFF
--- a/k8s/kdmp/kdmp.go
+++ b/k8s/kdmp/kdmp.go
@@ -23,6 +23,7 @@ var (
 type Ops interface {
 	DataExportOps
 	VolumeBackupOps
+	BackupLocationMaintenanceOps
 
 	// SetConfig sets the config and resets the client
 	SetConfig(config *rest.Config)


### PR DESCRIPTION

**What this PR does / why we need it**:
pb-1890: Add the BackupLocationMaintenanceOps to be part of kdmp Ops interface.

**Which issue(s) this PR fixes** (optional)
Closes # pb-1890

**Special notes for your reviewer**:

