### PR TITLE
pb-1916: Add the BackupDeleteOps to be part of kdmp Ops interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/openshift/api v0.0.0-20210105115604-44119421ec6b
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
 	// TODO: Vendor from pb-1874 branch. Need to change it to master.
-	github.com/portworx/kdmp v0.4.1-0.20210912113917-9ab5ca03f9ea
+	github.com/portworx/kdmp v0.4.1-0.20210929095959-dbee7f98b06f
 	github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.46.0
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.46.0

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,7 @@ github.com/ant31/crd-validation v0.0.0-20180702145049-30f8a35d0ac2/go.mod h1:X0n
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/aquilax/truncate v1.0.0/go.mod h1:BeMESIDMlvlS3bmg4BVvBbbZUNwWtS8uzYPAKXwwhLw=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -1013,6 +1014,10 @@ github.com/portworx/kdmp v0.4.1-0.20210907103225-5bf7fe9467ec h1:xOcDXA+BLJ+zoLp
 github.com/portworx/kdmp v0.4.1-0.20210907103225-5bf7fe9467ec/go.mod h1:y3gC3scahxunrBOWT/FyVjPTworM8JLBeeGHTlA48KQ=
 github.com/portworx/kdmp v0.4.1-0.20210912113917-9ab5ca03f9ea h1:7Fl9bCRWGc4hj4SNniHEOB4zuvOpp06Eu+HKrVkvBzs=
 github.com/portworx/kdmp v0.4.1-0.20210912113917-9ab5ca03f9ea/go.mod h1:y3gC3scahxunrBOWT/FyVjPTworM8JLBeeGHTlA48KQ=
+github.com/portworx/kdmp v0.4.1-0.20210925144549-1dd6d6e5c32b h1:AQ+3ZHeuPVIE4bBb8uQBe0vIhdww7mXFlFqZ3VxfH6k=
+github.com/portworx/kdmp v0.4.1-0.20210925144549-1dd6d6e5c32b/go.mod h1:EnclpJb9N3LVnY+O+YsPF75Hr9nmEtlQ0GNL0pRSrjQ=
+github.com/portworx/kdmp v0.4.1-0.20210929095959-dbee7f98b06f h1:/+jsyR4hiCIRgvCYYOIfEuTSaPibcLV/MStgWqEYxPg=
+github.com/portworx/kdmp v0.4.1-0.20210929095959-dbee7f98b06f/go.mod h1:k9yJD2Kvv9dyEkSv4J82t4nAsHJkPaV6jN0wq28MSmI=
 github.com/portworx/kvdb v0.0.0-20190105022415-cccaa09abfc9/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20191223203141-f42097b1fcd8/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200311180812-b2c72382d652/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
@@ -1027,6 +1032,7 @@ github.com/portworx/sched-ops v0.0.0-20210301232128-6cd5f08740bf/go.mod h1:nl2AP
 github.com/portworx/sched-ops v0.20.4-openstorage-rc3.0.20210325150944-0b2c202335f7/go.mod h1:DpRDDqXWQrReFJ5SHWWrURuZdzVKjrh2OxbAfwnrAyk=
 github.com/portworx/sched-ops v1.20.0-rc1/go.mod h1:nl2AP/W8sWmhmW7ScwNQrm5OCHiHjLYQ2NmO3TUjIhE=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20210805192436-d51186f75dc4/go.mod h1:+R+28pHhZ2Go7LquCo1+9ctpxwFGWak7zNcTFyXVh4k=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20210921050234-561b707a5d96/go.mod h1:y0JUD76QnRTNWv4tE2z9jpRxIWNB4RcP3S2g7UpAEOk=
 github.com/portworx/talisman v0.0.0-20191007232806-837747f38224 h1:r4LpGHxnh3tliXnaJcciROXU/snARMN6/OXhGPJyzGA=
 github.com/portworx/talisman v0.0.0-20191007232806-837747f38224/go.mod h1:OjpMH9Uh5o9ntVGktm4FbjLNwubJ3ITih2OfYrAeWtA=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7 h1:wAw+iv0bleZEvG48pelZvZ28m8InRUaugfCwOaLHiuE=

--- a/k8s/kdmp/kdmp.go
+++ b/k8s/kdmp/kdmp.go
@@ -23,6 +23,7 @@ var (
 type Ops interface {
 	DataExportOps
 	VolumeBackupOps
+	VolumeBackupDeleteOps
 	BackupLocationMaintenanceOps
 
 	// SetConfig sets the config and resets the client

--- a/k8s/kdmp/volumebackupdelete.go
+++ b/k8s/kdmp/volumebackupdelete.go
@@ -1,0 +1,64 @@
+package kdmp
+
+import (
+	"context"
+
+	kdmpv1alpha1 "github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// VolumeBackupDeleteOps is an interface to perfrom k8s volume delete CR crud operations
+type VolumeBackupDeleteOps interface {
+	// CreateVolumeBackupDelete creates the VolumeBackupDelete CR
+	CreateVolumeBackupDelete(*kdmpv1alpha1.VolumeBackupDelete) (*kdmpv1alpha1.VolumeBackupDelete, error)
+	// GetVolumeBackupDelete gets the VolumeBackupDelete CR
+	GetVolumeBackupDelete(string, string) (*kdmpv1alpha1.VolumeBackupDelete, error)
+	// ListVolumeBackupDelete lists all the VolumeBackupDelete CRs
+	ListVolumeBackupDelete(string) (*kdmpv1alpha1.VolumeBackupDeleteList, error)
+	// UpdateVolumeBackupDelete updates the VolumeBackupDelete CR
+	UpdateVolumeBackupDelete(*kdmpv1alpha1.VolumeBackupDelete) (*kdmpv1alpha1.VolumeBackupDelete, error)
+	// DeleteVolumeBackupDelete deletes the VolumeBackupDelete CR
+	DeleteVolumeBackupDelete(string, string) error
+}
+
+// CreateVolumeBackupDelete creates the VolumeBackupDelete CR
+func (c *Client) CreateVolumeBackupDelete(delete *kdmpv1alpha1.VolumeBackupDelete) (*kdmpv1alpha1.VolumeBackupDelete, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.kdmp.KdmpV1alpha1().VolumeBackupDeletes(delete.Namespace).Create(context.TODO(), delete, metav1.CreateOptions{})
+}
+
+// GetVolumeBackupDelete gets the VolumeBackupDelete CR
+func (c *Client) GetVolumeBackupDelete(name, namespace string) (*kdmpv1alpha1.VolumeBackupDelete, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.kdmp.KdmpV1alpha1().VolumeBackupDeletes(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+// ListVolumeBackupDelete lists all the VolumeBackupDelete CR
+func (c *Client) ListVolumeBackupDelete(namespace string) (*kdmpv1alpha1.VolumeBackupDeleteList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.kdmp.KdmpV1alpha1().VolumeBackupDeletes(namespace).List(context.TODO(), metav1.ListOptions{})
+}
+
+// DeleteVolumeBackupDelete deletes the VolumeBackupDelete CR
+func (c *Client) DeleteVolumeBackupDelete(name string, namespace string) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+	return c.kdmp.KdmpV1alpha1().VolumeBackupDeletes(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{
+		PropagationPolicy: &deleteForegroundPolicy,
+	})
+}
+
+// UpdateVolumeBackupDelete updates the VolumeBackupDelete CR
+func (c *Client) UpdateVolumeBackupDelete(delete *kdmpv1alpha1.VolumeBackupDelete) (*kdmpv1alpha1.VolumeBackupDelete, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.kdmp.KdmpV1alpha1().VolumeBackupDeletes(delete.Namespace).Update(context.TODO(), delete, metav1.UpdateOptions{})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
pb-1916: Add the BackupDeleteOps to be part of kdmp Ops interface
**Which issue(s) this PR fixes** (optional)
Closes # pb-1916

**Special notes for your reviewer**:

