### PR TITLE
PTX-4187 fix an issue when the master node is mistakenly marked as worker node

### DIFF
--- a/k8s/core/nodes.go
+++ b/k8s/core/nodes.go
@@ -135,7 +135,10 @@ func (c *Client) IsNodeReady(name string) error {
 
 // IsNodeMaster returns true if given node is a kubernetes master node
 func (c *Client) IsNodeMaster(node corev1.Node) bool {
-	if len(node.Labels[masterLabelKey]) > 0 || len(node.Labels[controlplaneLabelKey]) > 0 {
+	// for newer k8s these fields exist but they are empty
+	_, hasMasterLabel := node.Labels[masterLabelKey]
+	_, hasControlPlaneLabel := node.Labels[controlplaneLabelKey]
+	if hasMasterLabel || hasControlPlaneLabel {
 		return true
 	}
 	return false


### PR DESCRIPTION
Signed-off-by: Thiago Gonzaga <tgonzaga@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR fixes an issue on newer k8s when master nodes are not properly recognized as master due to empty values.

