### PR TITLE
Pb-1974 : Add APIs for listing resources with filter option enabled for CRs as well as for some built-in K8s resource.

### DIFF
--- a/k8s/batch/cron.go
+++ b/k8s/batch/cron.go
@@ -23,7 +23,7 @@ type CronOps interface {
 	// ValidateCronJob validates the given cronJob
 	ValidateCronJob(cronJob *v1beta1.CronJob, timeout, retryInterval time.Duration) error
 	// ListCronJobs list cronjobs in given namespace
-	ListCronJobs(namespace string) (*v1beta1.CronJobList, error)
+	ListCronJobs(namespace string, filterOptions metav1.ListOptions) (*v1beta1.CronJobList, error)
 }
 
 var NamespaceDefault = "default"
@@ -89,10 +89,10 @@ func (c *Client) ValidateCronJob(cronJob *v1beta1.CronJob, timeout, retryInterva
 }
 
 // ListCronJobs returns the cronJobs in given namespace
-func (c *Client) ListCronJobs(namespace string) (*v1beta1.CronJobList, error) {
+func (c *Client) ListCronJobs(namespace string, filterOptions metav1.ListOptions) (*v1beta1.CronJobList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
 
-	return c.batchv1beta1.CronJobs(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.batchv1beta1.CronJobs(namespace).List(context.TODO(), filterOptions)
 }

--- a/k8s/core/configmaps.go
+++ b/k8s/core/configmaps.go
@@ -21,6 +21,8 @@ type ConfigMapOps interface {
 	UpdateConfigMap(configMap *corev1.ConfigMap) (*corev1.ConfigMap, error)
 	// WatchConfigMap sets up a watcher that listens for changes on the config map
 	WatchConfigMap(configMap *corev1.ConfigMap, fn WatchFunc) error
+	//ListConfigMap returns the list of ConfigMaps
+	ListConfigMap(namespace string, filterOptions metav1.ListOptions) (*corev1.ConfigMapList, error)
 }
 
 // GetConfigMap gets the config map object for the given name and namespace
@@ -95,4 +97,14 @@ func (c *Client) WatchConfigMap(configMap *corev1.ConfigMap, fn WatchFunc) error
 	// fire off watch function
 	go c.handleWatch(watchInterface, configMap, "", fn, listOptions)
 	return nil
+}
+
+// ListConfigMap returns the list of ConfigMaps
+func (c *Client) ListConfigMap(namespace string, filterOptions metav1.ListOptions) (*corev1.ConfigMapList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.kubernetes.CoreV1().ConfigMaps(namespace).List(context.TODO(), filterOptions)
+
 }

--- a/k8s/kdmp/backuplocationmaintenance.go
+++ b/k8s/kdmp/backuplocationmaintenance.go
@@ -14,7 +14,7 @@ type BackupLocationMaintenanceOps interface {
 	// GetBackupLocationMaintenance gets the BackupLocationMaintenanc CR
 	GetBackupLocationMaintenance(string, string) (*kdmpv1alpha1.BackupLocationMaintenance, error)
 	// ListBackupLocationMaintenance lists all the BackupLocationMaintenance CRs
-	ListBackupLocationMaintenance(string) (*kdmpv1alpha1.BackupLocationMaintenanceList, error)
+	ListBackupLocationMaintenance(namespace string, filterOptions metav1.ListOptions) (*kdmpv1alpha1.BackupLocationMaintenanceList, error)
 	// UpdateBackupLocationMaintenance updates the BackupLocationMaintenance CR
 	UpdateBackupLocationMaintenance(*kdmpv1alpha1.BackupLocationMaintenance) (*kdmpv1alpha1.BackupLocationMaintenance, error)
 	// DeleteBackupLocationMaintenance deletes the BackupLocationMaintenance CR
@@ -38,11 +38,11 @@ func (c *Client) GetBackupLocationMaintenance(name, namespace string) (*kdmpv1al
 }
 
 // ListBackupLocationMaintenance lists all the BackupLocationMaintenance CR
-func (c *Client) ListBackupLocationMaintenance(namespace string) (*kdmpv1alpha1.BackupLocationMaintenanceList, error) {
+func (c *Client) ListBackupLocationMaintenance(namespace string, filterOptions metav1.ListOptions) (*kdmpv1alpha1.BackupLocationMaintenanceList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.kdmp.KdmpV1alpha1().BackupLocationMaintenances(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.kdmp.KdmpV1alpha1().BackupLocationMaintenances(namespace).List(context.TODO(), filterOptions)
 }
 
 // DeleteBackupLocationMaintenance deletes the BackupLocationMaintenance CR

--- a/k8s/kdmp/dataexport.go
+++ b/k8s/kdmp/dataexport.go
@@ -19,7 +19,7 @@ type DataExportOps interface {
 	// GetDataExport gets the DataExport CR
 	GetDataExport(string, string) (*kdmpv1alpha1.DataExport, error)
 	// ListDataExport lists all the DataExport CRs
-	ListDataExport(string) (*kdmpv1alpha1.DataExportList, error)
+	ListDataExport(namespace string, filterOptions metav1.ListOptions) (*kdmpv1alpha1.DataExportList, error)
 	// UpdateDataExport updates the DataExport CR
 	UpdateDataExport(*kdmpv1alpha1.DataExport) (*kdmpv1alpha1.DataExport, error)
 	// DeleteDataExport deletes the DataExport CR
@@ -45,11 +45,11 @@ func (c *Client) GetDataExport(name, namespace string) (*kdmpv1alpha1.DataExport
 }
 
 // ListDataExport lists all the DataExport CR
-func (c *Client) ListDataExport(namespace string) (*kdmpv1alpha1.DataExportList, error) {
+func (c *Client) ListDataExport(namespace string, filterOptions metav1.ListOptions) (*kdmpv1alpha1.DataExportList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.kdmp.KdmpV1alpha1().DataExports(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.kdmp.KdmpV1alpha1().DataExports(namespace).List(context.TODO(), filterOptions)
 }
 
 // DeleteDataExport deletes the DataExport CR

--- a/k8s/kdmp/volumebackup.go
+++ b/k8s/kdmp/volumebackup.go
@@ -14,7 +14,7 @@ type VolumeBackupOps interface {
 	// GetVolumeBackup gets the VolumeBackup CR
 	GetVolumeBackup(string, string) (*kdmpv1alpha1.VolumeBackup, error)
 	// ListVolumeBackup lists all the VolumeBackup CRs
-	ListVolumeBackup(string) (*kdmpv1alpha1.VolumeBackupList, error)
+	ListVolumeBackup(namespace string, filterOptions metav1.ListOptions) (*kdmpv1alpha1.VolumeBackupList, error)
 	// UpdateVolumeBackup updates the VolumeBackup CR
 	UpdateVolumeBackup(*kdmpv1alpha1.VolumeBackup) (*kdmpv1alpha1.VolumeBackup, error)
 	// DeleteVolumeBackup deletes the VolumeBackup CR
@@ -38,11 +38,11 @@ func (c *Client) GetVolumeBackup(name, namespace string) (*kdmpv1alpha1.VolumeBa
 }
 
 // ListVolumeBackup lists all the VolumeBackup CR
-func (c *Client) ListVolumeBackup(namespace string) (*kdmpv1alpha1.VolumeBackupList, error) {
+func (c *Client) ListVolumeBackup(namespace string, filterOptions metav1.ListOptions) (*kdmpv1alpha1.VolumeBackupList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.kdmp.KdmpV1alpha1().VolumeBackups(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.kdmp.KdmpV1alpha1().VolumeBackups(namespace).List(context.TODO(), filterOptions)
 }
 
 // DeleteVolumeBackup deletes the VolumeBackup CR

--- a/k8s/kdmp/volumebackupdelete.go
+++ b/k8s/kdmp/volumebackupdelete.go
@@ -14,7 +14,7 @@ type VolumeBackupDeleteOps interface {
 	// GetVolumeBackupDelete gets the VolumeBackupDelete CR
 	GetVolumeBackupDelete(string, string) (*kdmpv1alpha1.VolumeBackupDelete, error)
 	// ListVolumeBackupDelete lists all the VolumeBackupDelete CRs
-	ListVolumeBackupDelete(string) (*kdmpv1alpha1.VolumeBackupDeleteList, error)
+	ListVolumeBackupDelete(namespace string, filterOptions metav1.ListOptions) (*kdmpv1alpha1.VolumeBackupDeleteList, error)
 	// UpdateVolumeBackupDelete updates the VolumeBackupDelete CR
 	UpdateVolumeBackupDelete(*kdmpv1alpha1.VolumeBackupDelete) (*kdmpv1alpha1.VolumeBackupDelete, error)
 	// DeleteVolumeBackupDelete deletes the VolumeBackupDelete CR
@@ -38,11 +38,11 @@ func (c *Client) GetVolumeBackupDelete(name, namespace string) (*kdmpv1alpha1.Vo
 }
 
 // ListVolumeBackupDelete lists all the VolumeBackupDelete CR
-func (c *Client) ListVolumeBackupDelete(namespace string) (*kdmpv1alpha1.VolumeBackupDeleteList, error) {
+func (c *Client) ListVolumeBackupDelete(namespace string, filterOptions metav1.ListOptions) (*kdmpv1alpha1.VolumeBackupDeleteList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.kdmp.KdmpV1alpha1().VolumeBackupDeletes(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.kdmp.KdmpV1alpha1().VolumeBackupDeletes(namespace).List(context.TODO(), filterOptions)
 }
 
 // DeleteVolumeBackupDelete deletes the VolumeBackupDelete CR

--- a/k8s/rbac/rolebindings.go
+++ b/k8s/rbac/rolebindings.go
@@ -17,6 +17,8 @@ type RoleBindingOps interface {
 	GetRoleBinding(name, namespace string) (*rbacv1.RoleBinding, error)
 	// DeleteRoleBinding deletes the given role binding
 	DeleteRoleBinding(name, namespace string) error
+	// ListRoleBinding returns the list of role bindings
+	ListRoleBinding(namespace string, filterOptions metav1.ListOptions) (*rbacv1.RoleBindingList, error)
 }
 
 // CreateRoleBinding creates the given role binding
@@ -55,4 +57,13 @@ func (c *Client) DeleteRoleBinding(name, namespace string) error {
 	return c.rbac.RoleBindings(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
+}
+
+// ListRoleBinding returns the list of role bindings
+func (c *Client) ListRoleBinding(namespace string, filterOptions metav1.ListOptions) (*rbacv1.RoleBindingList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.rbac.RoleBindings(namespace).List(context.TODO(), filterOptions)
 }

--- a/k8s/rbac/roles.go
+++ b/k8s/rbac/roles.go
@@ -17,6 +17,8 @@ type RoleOps interface {
 	GetRole(name, namespace string) (*rbac_v1.Role, error)
 	// DeleteRole deletes the given role
 	DeleteRole(name, namespace string) error
+	// ListRoles returns the list of roles
+	ListRoles(namespace string, filterOptions metav1.ListOptions) (*rbac_v1.RoleList, error)
 }
 
 // CreateRole creates the given role
@@ -55,4 +57,13 @@ func (c *Client) DeleteRole(name, namespace string) error {
 	return c.rbac.Roles(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
+}
+
+// ListRoles returns the list of roles
+func (c *Client) ListRoles(namespace string, filterOptions metav1.ListOptions) (*rbac_v1.RoleList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.rbac.Roles(namespace).List(context.TODO(), filterOptions)
 }

--- a/k8s/stork/applicationbackuprestore.go
+++ b/k8s/stork/applicationbackuprestore.go
@@ -20,7 +20,7 @@ type ApplicationBackupRestoreOps interface {
 	// GetApplicationBackup gets the ApplicationBackup
 	GetApplicationBackup(string, string) (*storkv1alpha1.ApplicationBackup, error)
 	// ListApplicationBackups lists all the ApplicationBackups
-	ListApplicationBackups(string) (*storkv1alpha1.ApplicationBackupList, error)
+	ListApplicationBackups(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.ApplicationBackupList, error)
 	// UpdateApplicationBackup updates the ApplicationBackup
 	UpdateApplicationBackup(*storkv1alpha1.ApplicationBackup) (*storkv1alpha1.ApplicationBackup, error)
 	// DeleteApplicationBackup deletes the ApplicationBackup
@@ -34,7 +34,7 @@ type ApplicationBackupRestoreOps interface {
 	// GetApplicationRestore gets the ApplicationRestore
 	GetApplicationRestore(string, string) (*storkv1alpha1.ApplicationRestore, error)
 	// ListApplicationRestores lists all the ApplicationRestores
-	ListApplicationRestores(string) (*storkv1alpha1.ApplicationRestoreList, error)
+	ListApplicationRestores(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.ApplicationRestoreList, error)
 	// UpdateApplicationRestore updates the ApplicationRestore
 	UpdateApplicationRestore(*storkv1alpha1.ApplicationRestore) (*storkv1alpha1.ApplicationRestore, error)
 	// DeleteApplicationRestore deletes the ApplicationRestore
@@ -50,7 +50,7 @@ type ApplicationBackupRestoreOps interface {
 	// UpdateApplicationBackupSchedule updates the ApplicationBackupSchedule
 	UpdateApplicationBackupSchedule(*storkv1alpha1.ApplicationBackupSchedule) (*storkv1alpha1.ApplicationBackupSchedule, error)
 	// ListApplicationBackupSchedules lists all the ApplicationBackupSchedules
-	ListApplicationBackupSchedules(string) (*storkv1alpha1.ApplicationBackupScheduleList, error)
+	ListApplicationBackupSchedules(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.ApplicationBackupScheduleList, error)
 	// DeleteApplicationBackupSchedule deletes the ApplicationBackupSchedule
 	DeleteApplicationBackupSchedule(string, string) error
 	// ValidateApplicationBackupSchedule validates the given ApplicationBackupSchedule. It checks the status of each of
@@ -80,11 +80,11 @@ func (c *Client) GetApplicationBackup(name string, namespace string) (*storkv1al
 }
 
 // ListApplicationBackups lists all the ApplicationBackups
-func (c *Client) ListApplicationBackups(namespace string) (*storkv1alpha1.ApplicationBackupList, error) {
+func (c *Client) ListApplicationBackups(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.ApplicationBackupList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.StorkV1alpha1().ApplicationBackups(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().ApplicationBackups(namespace).List(context.TODO(), filterOptions)
 }
 
 // DeleteApplicationBackup deletes the ApplicationBackup
@@ -143,11 +143,11 @@ func (c *Client) GetApplicationRestore(name string, namespace string) (*storkv1a
 }
 
 // ListApplicationRestores lists all the ApplicationRestores
-func (c *Client) ListApplicationRestores(namespace string) (*storkv1alpha1.ApplicationRestoreList, error) {
+func (c *Client) ListApplicationRestores(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.ApplicationRestoreList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.StorkV1alpha1().ApplicationRestores(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().ApplicationRestores(namespace).List(context.TODO(), filterOptions)
 }
 
 // CreateApplicationRestore creates the ApplicationRestore
@@ -216,11 +216,11 @@ func (c *Client) GetApplicationBackupSchedule(name string, namespace string) (*s
 }
 
 // ListApplicationBackupSchedules lists all the ApplicationBackupSchedules
-func (c *Client) ListApplicationBackupSchedules(namespace string) (*storkv1alpha1.ApplicationBackupScheduleList, error) {
+func (c *Client) ListApplicationBackupSchedules(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.ApplicationBackupScheduleList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.StorkV1alpha1().ApplicationBackupSchedules(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().ApplicationBackupSchedules(namespace).List(context.TODO(), filterOptions)
 }
 
 // CreateApplicationBackupSchedule creates an ApplicationBackupSchedule

--- a/k8s/stork/backuplocation.go
+++ b/k8s/stork/backuplocation.go
@@ -18,7 +18,7 @@ type BackupLocationOps interface {
 	// GetBackupLocation gets the BackupLocation
 	GetBackupLocation(string, string) (*storkv1alpha1.BackupLocation, error)
 	// ListBackupLocations lists all the BackupLocations
-	ListBackupLocations(string) (*storkv1alpha1.BackupLocationList, error)
+	ListBackupLocations(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.BackupLocationList, error)
 	// UpdateBackupLocation updates the BackupLocation
 	UpdateBackupLocation(*storkv1alpha1.BackupLocation) (*storkv1alpha1.BackupLocation, error)
 	// DeleteBackupLocation deletes the BackupLocation
@@ -54,11 +54,11 @@ func (c *Client) GetBackupLocation(name string, namespace string) (*storkv1alpha
 }
 
 // ListBackupLocations lists all the BackupLocations
-func (c *Client) ListBackupLocations(namespace string) (*storkv1alpha1.BackupLocationList, error) {
+func (c *Client) ListBackupLocations(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.BackupLocationList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	backupLocations, err := c.stork.StorkV1alpha1().BackupLocations(namespace).List(context.TODO(), metav1.ListOptions{})
+	backupLocations, err := c.stork.StorkV1alpha1().BackupLocations(namespace).List(context.TODO(), filterOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/k8s/stork/namespacedschedulepolicy.go
+++ b/k8s/stork/namespacedschedulepolicy.go
@@ -14,7 +14,7 @@ type NamespacedSchedulePolicyOps interface {
 	// GetNamespacedSchedulePolicy gets the NamespacedSchedulePolicy
 	GetNamespacedSchedulePolicy(string, string) (*storkv1alpha1.NamespacedSchedulePolicy, error)
 	// ListNamespacedSchedulePolicies lists all the NamespacedSchedulePolicies
-	ListNamespacedSchedulePolicies(string) (*storkv1alpha1.NamespacedSchedulePolicyList, error)
+	ListNamespacedSchedulePolicies(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.NamespacedSchedulePolicyList, error)
 	// UpdateNamespacedSchedulePolicy updates the NamespacedSchedulePolicy
 	UpdateNamespacedSchedulePolicy(*storkv1alpha1.NamespacedSchedulePolicy) (*storkv1alpha1.NamespacedSchedulePolicy, error)
 	// DeleteNamespacedSchedulePolicy deletes the NamespacedSchedulePolicy
@@ -38,11 +38,11 @@ func (c *Client) GetNamespacedSchedulePolicy(name string, namespace string) (*st
 }
 
 // ListNamespacedSchedulePolicies lists all the NamespacedSchedulePolicies
-func (c *Client) ListNamespacedSchedulePolicies(namespace string) (*storkv1alpha1.NamespacedSchedulePolicyList, error) {
+func (c *Client) ListNamespacedSchedulePolicies(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.NamespacedSchedulePolicyList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.StorkV1alpha1().NamespacedSchedulePolicies(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().NamespacedSchedulePolicies(namespace).List(context.TODO(), filterOptions)
 }
 
 // UpdateNamespacedSchedulePolicy updates the NamespacedSchedulePolicy

--- a/k8s/stork/rule.go
+++ b/k8s/stork/rule.go
@@ -17,6 +17,8 @@ type RuleOps interface {
 	UpdateRule(rule *storkv1alpha1.Rule) (*storkv1alpha1.Rule, error)
 	// DeleteRule deletes the given stork rule
 	DeleteRule(name, namespace string) error
+	// ListRules returns the list of rules
+	ListRules(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.RuleList, error)
 }
 
 // GetRule fetches the given stork rule
@@ -51,4 +53,12 @@ func (c *Client) DeleteRule(name, namespace string) error {
 	return c.stork.StorkV1alpha1().Rules(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
+}
+
+// ListRules returns the list of rules
+func (c *Client) ListRules(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.RuleList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.stork.StorkV1alpha1().Rules(namespace).List(context.TODO(), filterOptions)
 }


### PR DESCRIPTION
**What this PR does / why we need it**: This PR adds filter options to APIs so that List resources will return based on various filters provided by user. This will be used by triage tools. Following resources are enabled with such features.
applicationbackup. — Done
applicationrestore. — Done
applicationbackupschedule —Done
backuplocation —Done
rules  — Not Done
schedulepolicy  — Done
dataexport. — Done
volumebackup —Done
rolebindings. —Done
volumebackupdelete —Done
backuplocationmaintenace —Done
role —Done
jobs -- already expects user to fill metav1.ListOptions, hence didn't alter
cronjobs --already expects user to fill metav1.ListOptions, hence didn't alter
secret --already expects user to fill metav1.ListOptions, hence didn't alter
configmap --already expects user to fill metav1.ListOptions, hence didn't alter
serviceaccount --already expects user to fill metav1.ListOptions, hence didn't alter
**Which issue(s) this PR fixes** (optional)
Closes # pb-1974

**Special notes for your reviewer**:
For certain resources which are built-in resources of K8s infra are having wrapper APIs which expects user to populated metav1.ListOption struct and pass to wrapper thats how it filters unlike providing generic Data-structure. By generic DS it is meant for labels it is map[string]string & string for namespace etc.... Hence didn't alter the existing ones or added any new wrapper. 
