### PR TITLE
Fixed PVC size in params

### DIFF
--- a/k8s/core/persistentvolumeclaims.go
+++ b/k8s/core/persistentvolumeclaims.go
@@ -258,9 +258,7 @@ func (c *Client) GetPersistentVolumeClaimParams(pvc *corev1.PersistentVolumeClai
 		return nil, fmt.Errorf("failed to get storage resource for pvc: %v", result.Name)
 	}
 
-	// We explicitly send the unit with so the client can compare it with correct units
-	requestGB := uint64(roundUpSize(capacity.Value(), 1024*1024*1024))
-	params["size"] = fmt.Sprintf("%dG", requestGB)
+	params["size"] = capacity.String()
 
 	sc, err := c.GetStorageClassForPVC(result)
 	if err != nil {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Fixed the issue with PVC size when the size is not an integer, for example 23.625 GB. Autopilot automation fails as it does couple resizes from 7GB by 50% (7 -> 10.5 -> 15.75 -> 23.625).

