### PR TITLE
pb-1992: Added getPodLog API for extracting logs.

### DIFF
--- a/k8s/core/pods.go
+++ b/k8s/core/pods.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/portworx/sched-ops/k8s/common"
@@ -68,6 +69,8 @@ type PodOps interface {
 	ValidatePod(pod *corev1.Pod, timeout, retryInterval time.Duration) error
 	// WatchPods sets up a watcher that listens for the changes to pods in given namespace
 	WatchPods(namespace string, fn WatchFunc, listOptions metav1.ListOptions) error
+	// GetPodLogs returns the logs of a POD as a string
+	GetPodLog(podName string, namespace string, podLogOptions *corev1.PodLogOptions) (string, error)
 }
 
 // DeletePods deletes the given pods
@@ -461,6 +464,29 @@ func (c *Client) RunCommandInPod(cmds []string, podName, containerName, namespac
 	}
 
 	return execOut.String(), nil
+}
+
+// GetPodLog returns the logs of a POD as a string
+func (c *Client) GetPodLog(podName string, ns string, podLogOptions *corev1.PodLogOptions) (string, error) {
+	if err := c.initClient(); err != nil {
+		return "", err
+	}
+
+	l := c.kubernetes.CoreV1().Pods(ns).GetLogs(podName, podLogOptions)
+	buf := new(bytes.Buffer)
+	stream, err := l.Stream(context.TODO())
+	if err != nil {
+		return "", err
+	}
+	defer stream.Close()
+
+	_, err = io.Copy(buf, stream)
+	if err != nil {
+		return "", err
+	}
+	str := buf.String()
+
+	return str, err
 }
 
 // isAnyVolumeUsingVolumePlugin returns true if any of the given volumes is using a storage class for the given plugin


### PR DESCRIPTION
For storing the log of a POD we need to have API so that
user can read the LOG of a POD programatically.

**What this PR does / why we need it**:  Need a API for reading the LOGs of a POD programatically for the triage tool

**Which issue(s) this PR fixes** (optional)
Closes #pb-1992

**Special notes for your reviewer**:

