### PR TITLE
PWX-21358: Adding configmap locks to sched-ops

### DIFF
--- a/k8s/core/configmap/configmap.go
+++ b/k8s/core/configmap/configmap.go
@@ -1,0 +1,181 @@
+package configmap
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/portworx/sched-ops/k8s/core"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// New returns the ConfigMap interface. It also creates a new
+// configmap in k8s for the given name if not present and puts the data in it.
+func New(
+	name string,
+	data map[string]string,
+	lockTimeout time.Duration,
+	lockAttempts uint,
+	lockRefreshDuration time.Duration,
+	lockK8sLockTTL time.Duration,
+) (ConfigMap, error) {
+	if data == nil {
+		data = make(map[string]string)
+	}
+
+	labels := map[string]string{
+		configMapUserLabelKey: TruncateLabel(name),
+	}
+	data[pxOwnerKey] = ""
+
+	cm := &v1.ConfigMap{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      name,
+			Namespace: k8sSystemNamespace,
+			Labels:    labels,
+		},
+		Data: data,
+	}
+
+	if _, err := core.Instance().CreateConfigMap(cm); err != nil &&
+		!k8s_errors.IsAlreadyExists(err) {
+		return nil, fmt.Errorf("Failed to create configmap %v: %v",
+			name, err)
+	}
+	return &configMap{
+		name:                name,
+		lockTimeout:         lockTimeout,
+		kLocksV2:            map[string]*k8sLock{},
+		lockAttempts:        lockAttempts,
+		lockRefreshDuration: lockRefreshDuration,
+		lockK8sLockTTL:      lockK8sLockTTL,
+	}, nil
+}
+
+func (c *configMap) Get() (map[string]string, error) {
+	cm, err := core.Instance().GetConfigMap(
+		c.name,
+		k8sSystemNamespace,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return cm.Data, nil
+}
+
+func (c *configMap) Delete() error {
+	return core.Instance().DeleteConfigMap(
+		c.name,
+		k8sSystemNamespace,
+	)
+}
+
+func (c *configMap) Patch(data map[string]string) error {
+	var (
+		err error
+		cm  *corev1.ConfigMap
+	)
+	for retries := 0; retries < maxConflictRetries; retries++ {
+		cm, err = core.Instance().GetConfigMap(
+			c.name,
+			k8sSystemNamespace,
+		)
+		if err != nil {
+			return err
+		}
+
+		if cm.Data == nil {
+			cm.Data = make(map[string]string, 0)
+		}
+
+		for k, v := range data {
+			cm.Data[k] = v
+		}
+		_, err = core.Instance().UpdateConfigMap(cm)
+		if k8s_errors.IsConflict(err) {
+			// try again
+			continue
+		}
+		return err
+	}
+	return err
+}
+
+func (c *configMap) Update(data map[string]string) error {
+	var (
+		err error
+		cm  *corev1.ConfigMap
+	)
+	for retries := 0; retries < maxConflictRetries; retries++ {
+		cm, err = core.Instance().GetConfigMap(
+			c.name,
+			k8sSystemNamespace,
+		)
+		if err != nil {
+			return err
+		}
+		cm.Data = data
+		_, err = core.Instance().UpdateConfigMap(cm)
+		if k8s_errors.IsConflict(err) {
+			// try again
+			continue
+		}
+		return err
+	}
+	return err
+}
+
+// SetFatalCb sets the fatal callback for the package which will get invoked in panic situations
+func SetFatalCb(fb FatalCb) {
+	fatalCb = fb
+}
+
+func configMapLog(fn, name, owner, key string, err error) *logrus.Entry {
+	if len(owner) > 0 && len(key) > 0 {
+		return logrus.WithFields(logrus.Fields{
+			"Module":   "ConfigMap",
+			"Name":     name,
+			"Owner":    owner,
+			"Key":      key,
+			"Function": fn,
+			"Error":    err,
+		})
+	}
+	if len(owner) > 0 {
+		return logrus.WithFields(logrus.Fields{
+			"Module":   "ConfigMap",
+			"Name":     name,
+			"Owner":    owner,
+			"Function": fn,
+			"Error":    err,
+		})
+	}
+	return logrus.WithFields(logrus.Fields{
+		"Module":   "ConfigMap",
+		"Name":     name,
+		"Function": fn,
+		"Error":    err,
+	})
+}
+
+// GetName is a helper function that returns a valid k8s
+// configmap name given a prefix identifying the component using
+// the configmap and a clusterID
+func GetName(prefix, clusterID string) string {
+	return prefix + strings.ToLower(configMapNameRegex.ReplaceAllString(clusterID, ""))
+}
+
+// TruncateLabel is a helper function that returns a valid k8s
+// label stripped down to 63 characters. It removes the trailing characters
+func TruncateLabel(label string) string {
+	if len(label) > 63 {
+		return label[:63]
+	}
+	return label
+}

--- a/k8s/core/configmap/configmap_lock_v1.go
+++ b/k8s/core/configmap/configmap_lock_v1.go
@@ -1,0 +1,173 @@
+package configmap
+
+import (
+	"github.com/portworx/sched-ops/k8s/core"
+	corev1 "k8s.io/api/core/v1"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	"time"
+)
+
+func (c *configMap) Lock(id string) error {
+	fn := "Lock"
+	count := uint(0)
+	// try acquiring a lock on the ConfigMap
+	owner, err := c.tryLockV1(id, false)
+	// This is the same no. of times (300) we try while acquiring a kvdb lock
+	for maxCount := c.lockAttempts; err != nil && count < maxCount; count++ {
+		time.Sleep(lockSleepDuration)
+		owner, err = c.tryLockV1(id, false)
+		if count > 0 && count%15 == 0 && err != nil {
+			configMapLog(fn, c.name, owner, "", err).Warnf("Locked for"+
+				" %v seconds", float64(count)*lockSleepDuration.Seconds())
+		}
+	}
+	if err != nil {
+		// We failed to acquire the lock
+		return err
+	}
+	if count >= 30 {
+		configMapLog(fn, c.name, owner, "", err).Warnf("Spent %v iteration"+
+			" locking.", count)
+	}
+	c.kLockV1 = k8sLock{done: make(chan struct{}), id: id}
+	go c.refreshLockV1(id)
+	return nil
+}
+
+func (c *configMap) Unlock() error {
+	fn := "Unlock"
+	// Get the existing ConfigMap
+	c.kLockV1.Lock()
+	defer c.kLockV1.Unlock()
+	if c.kLockV1.unlocked {
+		// The lock is already unlocked
+		return nil
+	}
+	c.kLockV1.unlocked = true
+	c.kLockV1.done <- struct{}{}
+
+	var (
+		err error
+		cm  *corev1.ConfigMap
+	)
+
+	for retries := 0; retries < maxConflictRetries; retries++ {
+		cm, err = core.Instance().GetConfigMap(
+			c.name,
+			k8sSystemNamespace,
+		)
+		if err != nil {
+			// A ConfigMap should always be created.
+			return err
+		}
+
+		currentOwner := cm.Data[pxOwnerKey]
+		if currentOwner != c.kLockV1.id {
+			// We are currently not holding the lock
+			return nil
+		}
+		delete(cm.Data, pxOwnerKey)
+		delete(cm.Data, pxExpirationKey)
+
+		if _, err = core.Instance().UpdateConfigMap(cm); err != nil {
+			configMapLog(fn, c.name, "", "", err).Errorf("Failed to update" +
+				" config map during unlock")
+			if k8s_errors.IsConflict(err) {
+				// try unlocking again
+				continue
+			} // else unknown error - return immediately
+			return err
+		}
+		c.kLockV1.id = ""
+		return nil
+	}
+
+	return err
+}
+
+func (c *configMap) tryLockV1(id string, refresh bool) (string, error) {
+	// Get the existing ConfigMap
+	cm, err := core.Instance().GetConfigMap(
+		c.name,
+		k8sSystemNamespace,
+	)
+	if err != nil {
+		// A ConfigMap should always be created.
+		return "", err
+	}
+
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+
+	currentOwner := cm.Data[pxOwnerKey]
+	if currentOwner != "" {
+		if currentOwner == id && refresh {
+			// We already hold the lock just refresh
+			// our expiry
+			goto increase_expiry
+		} // refresh not requested
+		// Someone might have a lock on the cm
+		// Check expiration
+		expiration := cm.Data[pxExpirationKey]
+		if expiration != "" {
+			expiresAt, err := time.Parse(time.UnixDate, expiration)
+			if err != nil {
+				return currentOwner, err
+			}
+			if time.Now().Before(expiresAt) {
+				// Lock is currently held by the owner
+				// Retry after sometime
+				return currentOwner, ErrConfigMapLocked
+			} // else lock is expired. Try to lock it.
+		}
+	}
+
+	// Take the lock or increase our expiration if we are already holding the lock
+	cm.Data[pxOwnerKey] = id
+increase_expiry:
+	cm.Data[pxExpirationKey] = time.Now().Add(v1DefaultK8sLockTTL).Format(time.UnixDate)
+
+	if _, err = core.Instance().UpdateConfigMap(cm); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+func (c *configMap) refreshLockV1(id string) {
+	fn := "refreshLock"
+	refresh := time.NewTicker(v1DefaultK8sLockRefreshDuration)
+	var (
+		currentRefresh time.Time
+		prevRefresh    time.Time
+		startTime      time.Time
+	)
+	startTime = time.Now()
+	defer refresh.Stop()
+	for {
+		select {
+		case <-refresh.C:
+			c.kLockV1.Lock()
+			for !c.kLockV1.unlocked {
+				c.checkLockTimeout(startTime, id)
+				currentRefresh = time.Now()
+				if _, err := c.tryLockV1(id, true); err != nil {
+					configMapLog(fn, c.name, "", "", err).Errorf(
+						"Error refreshing lock. [Owner %v] [Err: %v]"+
+							" [Current Refresh: %v] [Previous Refresh: %v]",
+						id, err, currentRefresh, prevRefresh,
+					)
+					if k8s_errors.IsConflict(err) {
+						// try refreshing again
+						continue
+					}
+				}
+				prevRefresh = currentRefresh
+				break
+			}
+			c.kLockV1.Unlock()
+		case <-c.kLockV1.done:
+			return
+		}
+	}
+}

--- a/k8s/core/configmap/configmap_lock_v1_test.go
+++ b/k8s/core/configmap/configmap_lock_v1_test.go
@@ -1,0 +1,108 @@
+package configmap
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	coreops "github.com/portworx/sched-ops/k8s/core"
+	"github.com/stretchr/testify/require"
+	fakek8sclient "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestLock(t *testing.T) {
+	fakeClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(fakeClient))
+	cm, err := New("px-configmaps-test", nil, lockTimeout, 5, 0, 0)
+	require.NoError(t, err, "Unexpected error on New")
+	fmt.Println("testLock")
+
+	id := "locktest"
+	err = cm.Lock(id)
+	require.NoError(t, err, "Unexpected error in lock")
+
+	fmt.Println("\tunlock")
+	err = cm.Unlock()
+	require.NoError(t, err, "Unexpected error from Unlock")
+
+	fmt.Println("\trelock")
+	err = cm.Lock(id)
+	require.NoError(t, err, "Failed to lock after unlock")
+
+	fmt.Println("\treunlock")
+	err = cm.Unlock()
+	require.NoError(t, err, "Unexpected error from Unlock")
+
+	fmt.Println("\trepeat lock once")
+	err = cm.Lock(id)
+	require.NoError(t, err, "Failed to lock unlock")
+
+	done := 0
+	go func() {
+		time.Sleep(time.Second * 3)
+		done = 1
+		err := cm.Unlock()
+		fmt.Println("\trepeat lock unlock once")
+		require.NoError(t, err, "Unexpected error from Unlock")
+	}()
+	fmt.Println("\trepeat lock lock twice")
+	err = cm.Lock(id)
+	require.NoError(t, err, "Failed to lock")
+	require.Equal(t, 1, done, "Locked before unlock")
+	fmt.Println("\trepeat lock unlock twice")
+	err = cm.Unlock()
+	require.NoError(t, err, "Unexpected error from Unlock")
+
+	for done == 0 {
+		time.Sleep(time.Second)
+	}
+
+	id = "doubleLock"
+	err = cm.Lock(id)
+	require.NoError(t, err, "Unexpected error in lock")
+	go func() {
+		time.Sleep(3 * time.Second)
+		err := cm.Unlock()
+		require.NoError(t, err, "Unexpected error from Unlock")
+	}()
+	err = cm.Lock(id)
+	require.NoError(t, err, "Double lock")
+	err = cm.Unlock()
+	require.NoError(t, err, "Unexpected error from Unlock")
+
+	err = cm.Lock("id1")
+	require.NoError(t, err, "Unexpected error in lock")
+	go func() {
+		time.Sleep(1 * time.Second)
+		err := cm.Unlock()
+		require.NoError(t, err, "Unexpected error from Unlock")
+	}()
+	err = cm.Lock("id2")
+	require.NoError(t, err, "diff lock")
+	err = cm.Unlock()
+	require.NoError(t, err, "Unexpected error from Unlock")
+
+	fmt.Println("\tlockExpiration")
+
+	var lockTimedout bool
+	fatalLockCb := func(format string, args ...interface{}) {
+		fmt.Println("\tLock timeout called.")
+		lockTimedout = true
+		err := cm.Unlock()
+		require.NoError(t, err, "Unexpected error from Unlock")
+	}
+	SetFatalCb(fatalLockCb)
+
+	// Check lock expiration
+	err = cm.Lock("id2")
+	require.NoError(t, err, "Unexpected error in lock")
+	time.Sleep(20 * time.Second)
+	require.True(t, lockTimedout, "Lock hold timeout not triggered")
+
+	err = cm.Lock("id3")
+	require.NoError(t, err, "Lock should have expired")
+	err = cm.Unlock()
+	require.NoError(t, err, "Unexpected no error in unlock")
+	err = cm.Delete()
+	require.NoError(t, err, "Unexpected error on Delete")
+}

--- a/k8s/core/configmap/configmap_lock_v2.go
+++ b/k8s/core/configmap/configmap_lock_v2.go
@@ -1,0 +1,365 @@
+package configmap
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/libopenstorage/openstorage/pkg/dbg"
+	"github.com/portworx/sched-ops/k8s/core"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func (c *configMap) LockWithKey(owner, key string) error {
+	if key == "" {
+		return fmt.Errorf("key cannot be empty")
+	}
+
+	fn := "LockWithKey"
+	count := uint(0)
+	// try acquiring a lock on the ConfigMap
+	newOwner, err := c.tryLock(owner, key, false)
+	// if it fails, keep trying for the provided number of retries until it succeeds
+	for maxCount := c.lockAttempts; err != nil && count < maxCount; count++ {
+		time.Sleep(lockSleepDuration)
+		newOwner, err = c.tryLock(owner, key, false)
+		if count > 0 && count%15 == 0 && err != nil {
+			configMapLog(fn, c.name, newOwner, key, err).Warnf("Locked for"+
+				" %v seconds", float64(count)*lockSleepDuration.Seconds())
+		}
+	}
+	if err != nil {
+		// We failed to acquire the lock
+		return err
+	}
+	if count >= 30 {
+		configMapLog(fn, c.name, newOwner, key, err).Warnf("Spent %v iteration"+
+			" locking.", count)
+	}
+	c.kLocksV2Mutex.Lock()
+	c.kLocksV2[key] = &k8sLock{done: make(chan struct{}), id: owner}
+	c.kLocksV2Mutex.Unlock()
+
+	go c.refreshLock(owner, key)
+	return nil
+}
+
+func (c *configMap) UnlockWithKey(key string) error {
+	if key == "" {
+		return fmt.Errorf("key cannot be empty")
+	}
+
+	fn := "UnlockWithKey"
+
+	// Get the lock reference now so we don't have to keep locking and unlocking
+	c.kLocksV2Mutex.Lock()
+	lock, ok := c.kLocksV2[key]
+	c.kLocksV2Mutex.Unlock()
+	if !ok {
+		return nil
+	}
+
+	lock.Lock()
+	defer lock.Unlock()
+
+	if lock.unlocked {
+		// The lock is already unlocked
+		return nil
+	}
+	lock.unlocked = true
+	lock.done <- struct{}{}
+
+	var (
+		err error
+		cm  *v1.ConfigMap
+	)
+
+	// Get the existing ConfigMap
+	for retries := 0; retries < maxConflictRetries; retries++ {
+		cm, err = core.Instance().GetConfigMap(
+			c.name,
+			k8sSystemNamespace,
+		)
+		if err != nil {
+			// A ConfigMap should always be created.
+			return err
+		}
+
+		lockOwners, lockExpirations, err := c.parseLocks(cm)
+		if err != nil {
+			return fmt.Errorf("failed to get locks from configmap: %v", err)
+		}
+
+		currentOwner := lockOwners[key]
+		if currentOwner != lock.id {
+			return nil
+		}
+
+		// We are holding the lock, let's remove it
+		delete(lockOwners, key)
+		delete(lockExpirations, key)
+
+		err = c.generateConfigMapData(cm, lockOwners, lockExpirations)
+		if err != nil {
+			return err
+		}
+
+		if k8sConflict, err := c.updateConfigMap(cm); err != nil {
+			configMapLog(fn, c.name, "", "", err).Errorf("Failed to update" +
+				" config map during unlock")
+			if k8sConflict {
+				// try unlocking again
+				continue
+			}
+			// else unknown error - return immediately
+			return err
+		}
+
+		// Clean up the lock
+		c.kLocksV2Mutex.Lock()
+		delete(c.kLocksV2, key)
+		c.kLocksV2Mutex.Unlock()
+		return nil
+	}
+
+	return err
+}
+
+func (c *configMap) IsKeyLocked(key string) (bool, string, error) {
+	// Get the existing ConfigMap
+	cm, err := core.Instance().GetConfigMap(
+		c.name,
+		k8sSystemNamespace,
+	)
+	if err != nil {
+		return false, "", err
+	}
+
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+
+	lockIDs, lockExpirations, err := c.parseLocks(cm)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to get locks from configmap: %v", err)
+	}
+
+	if owner, ok := lockIDs[key]; ok {
+		// Someone owns the lock: let's check the expiration and the owner
+		expiration := lockExpirations[key]
+		if time.Now().After(expiration) {
+			// Lock is expired
+			return false, "", nil
+		}
+
+		return true, owner, nil
+	}
+
+	// Nobody owns the lock
+	return false, "", nil
+}
+
+func (c *configMap) tryLock(owner string, key string, refresh bool) (string, error) {
+	// Get the existing ConfigMap
+	cm, err := core.Instance().GetConfigMap(
+		c.name,
+		k8sSystemNamespace,
+	)
+	if err != nil {
+		// A ConfigMap should always be created.
+		return "", err
+	}
+
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+
+	lockIDs, lockExpirations, err := c.parseLocks(cm)
+	if err != nil {
+		return "", fmt.Errorf("failed to get locks from configmap: %v", err)
+	}
+
+	finalOwner, err := c.checkAndTakeLock(owner, key, refresh, lockIDs, lockExpirations)
+	if err != nil {
+		return finalOwner, err
+	}
+
+	err = c.generateConfigMapData(cm, lockIDs, lockExpirations)
+	if err != nil {
+		return finalOwner, err
+	}
+
+	if _, err := c.updateConfigMap(cm); err != nil {
+		return "", err
+	}
+	return owner, nil
+}
+
+// parseLocks reads the lock data from the given ConfigMap and then converts it to:
+// * a map of keys to lock owners
+// * a map of keys to lock expiration times
+func (c *configMap) parseLocks(cm *v1.ConfigMap) (map[string]string, map[string]time.Time, error) {
+	// Check all the locks: will be an empty string if key is not present indicating no lock
+	parsedLocks := []lockData{}
+	if lock, ok := cm.Data[pxLockKey]; ok && len(lock) > 0 {
+		err := json.Unmarshal([]byte(cm.Data[pxLockKey]), &parsedLocks)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// Check all the locks first and store them, makes the looping a little easier
+	lockOwners := map[string]string{}
+	lockExpirations := map[string]time.Time{}
+
+	for _, lock := range parsedLocks {
+		lockOwners[lock.Key] = lock.Owner
+		lockExpirations[lock.Key] = lock.Expiration
+	}
+
+	return lockOwners, lockExpirations, nil
+}
+
+// checkAndTakeLock tries to take the given lock (owner, key) given the current state of the lock
+// (lockOwners, lockExpirations). Refresh indicates if this is the refreshLock goroutine
+// refreshing the lock or an initial Lock call taking the lock.
+func (c *configMap) checkAndTakeLock(owner, key string, refresh bool,
+	lockOwners map[string]string, lockExpirations map[string]time.Time) (string, error) {
+	fn := "checkAndTakeLock"
+
+	_, ownerOK := lockOwners[key]
+	_, expOK := lockExpirations[key]
+
+	// Just check to make sure these are consistent and that we either have both or don't
+	if ownerOK != expOK {
+		return "", fmt.Errorf("inconsistent lock ID and expiration")
+	}
+	k8sTTL := v2DefaultK8sLockTTL
+	if c.lockK8sLockTTL > 0 {
+		k8sTTL = c.lockK8sLockTTL
+	}
+
+	// Now that we've parsed all the lock lines, let's check the specific key we're taking
+	if !ownerOK {
+		// There is no lock, we can take it
+		lockOwners[key] = owner
+		lockExpirations[key] = time.Now().Add(k8sTTL)
+		return owner, nil
+	}
+
+	// There is a lock: let's check it out and see what the details are
+
+	// First let's see if we're refreshing and who holds it
+	if refresh && lockOwners[key] == owner {
+		// We hold the lock, just refresh it
+		lockExpirations[key] = time.Now().Add(k8sTTL)
+		return owner, nil
+	}
+
+	// Now let's see if the lock is expired or not: if it's not expired, we can't take it
+	if time.Now().Before(lockExpirations[key]) {
+		return lockOwners[key], ErrConfigMapLocked
+	}
+
+	configMapLog(fn, c.name, owner, key, nil).Infof("Lock from owner '%s' is expired, now claiming for new owner '%s'", lockOwners[key], owner)
+
+	// Lock is expired: let's take it
+	lockOwners[key] = owner
+	lockExpirations[key] = time.Now().Add(k8sTTL)
+	return owner, nil
+}
+
+// generateConfigMapData converts the given lock data (lockOwners, lockExpirations) to JSON and
+// stores it in the given ConfigMap.
+func (c *configMap) generateConfigMapData(cm *v1.ConfigMap, lockOwners map[string]string, lockExpirations map[string]time.Time) error {
+	var locks []lockData
+	for key, lockOwner := range lockOwners {
+		locks = append(locks, lockData{
+			Owner:      lockOwner,
+			Key:        key,
+			Expiration: lockExpirations[key],
+		})
+	}
+
+	cmData, err := json.Marshal(locks)
+	if err != nil {
+		return err
+	}
+	cm.Data[pxLockKey] = string(cmData)
+	return nil
+}
+
+func (c *configMap) updateConfigMap(cm *v1.ConfigMap) (bool, error) {
+	if _, err := core.Instance().UpdateConfigMap(cm); err != nil {
+		return k8s_errors.IsConflict(err), err
+	}
+	return false, nil
+}
+
+// refreshLock is the goroutine running in the background after calling LockWithKey.
+// It keeps the lock refreshed in k8s until we call Unlock. This is so that if the
+// node dies, the lock can have a short timeout and expire quickly but we can still
+// take longer-term locks.
+func (c *configMap) refreshLock(id, key string) {
+	fn := "refreshLock"
+	refresh := time.NewTicker(v2DefaultK8sLockRefreshDuration)
+	if c.lockRefreshDuration > 0 {
+		refresh = time.NewTicker(c.lockRefreshDuration)
+	}
+	var (
+		currentRefresh time.Time
+		prevRefresh    time.Time
+		startTime      time.Time
+	)
+
+	// get a reference to the lock object so we don't have to hold open a
+	// map reference - this makes it easier for concurrency purposes (can't
+	// lock in a select condition)
+	c.kLocksV2Mutex.Lock()
+	lock := c.kLocksV2[key]
+	c.kLocksV2Mutex.Unlock()
+
+	startTime = time.Now()
+	defer refresh.Stop()
+	for {
+		select {
+		case <-refresh.C:
+			lock.Lock()
+
+			for !lock.unlocked {
+				c.checkLockTimeout(startTime, id)
+				currentRefresh = time.Now()
+				if _, err := c.tryLock(id, key, true); err != nil {
+					configMapLog(fn, c.name, "", key, err).Errorf(
+						"Error refreshing lock. [ID %v] [Key %v] [Err: %v]"+
+							" [Current Refresh: %v] [Previous Refresh: %v]",
+						id, key, err, currentRefresh, prevRefresh,
+					)
+					if k8s_errors.IsConflict(err) {
+						// try refreshing again
+						continue
+					}
+				}
+				prevRefresh = currentRefresh
+				break
+			}
+			lock.Unlock()
+		case <-lock.done:
+			return
+		}
+	}
+
+}
+
+func (c *configMap) checkLockTimeout(startTime time.Time, id string) {
+	if c.lockTimeout > 0 && time.Since(startTime) > c.lockTimeout {
+		panicMsg := fmt.Sprintf("Lock timeout triggered for K8s configmap lock key %s", id)
+		if fatalCb != nil {
+			fatalCb(panicMsg)
+		} else {
+			dbg.Panicf(panicMsg)
+		}
+	}
+}

--- a/k8s/core/configmap/configmap_lock_v2_test.go
+++ b/k8s/core/configmap/configmap_lock_v2_test.go
@@ -1,0 +1,134 @@
+package configmap
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	coreops "github.com/portworx/sched-ops/k8s/core"
+	"github.com/stretchr/testify/require"
+	fakek8sclient "k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	lockTimeout = 15 * time.Second
+)
+
+func TestMultilock(t *testing.T) {
+	fakeClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(fakeClient))
+	cm, err := New("px-configmaps-test", nil, lockTimeout, 3, 0, 0)
+	require.NoError(t, err, "Unexpected error on New")
+
+	fmt.Println("testMultilock")
+
+	id1 := "id1"
+	id2 := "id2"
+	key1 := "key1"
+	key2 := "key2"
+
+	locked, _, err := cm.IsKeyLocked(key1)
+	require.NoError(t, err)
+	require.False(t, locked)
+
+	err = cm.LockWithKey(id1, key1)
+	require.NoError(t, err, "Unexpected error in LockWithKey(id1,key1)")
+
+	locked, owner, err := cm.IsKeyLocked(key1)
+	require.NoError(t, err)
+	require.True(t, locked)
+	require.Equal(t, id1, owner)
+
+	fmt.Println("\tlocking key 2")
+	err = cm.LockWithKey(id2, key2)
+	require.NoError(t, err, "Unexpected error in LockWithKey(id2,key2)")
+
+	locked, owner, err = cm.IsKeyLocked(key2)
+	require.NoError(t, err)
+	require.True(t, locked)
+	require.Equal(t, id2, owner)
+
+	fmt.Println("\tunlocking key 1")
+	err = cm.UnlockWithKey(key1)
+	require.NoError(t, err, "Unexpected error in UnlockWithKey(id1,key1)")
+
+	locked, owner, err = cm.IsKeyLocked(key1)
+	require.NoError(t, err)
+	require.False(t, locked)
+
+	fmt.Println("\tunlocking key 2")
+	err = cm.UnlockWithKey(key2)
+	require.NoError(t, err, "Unexpected error in UnlockWithKey(id1,key1)")
+
+	locked, owner, err = cm.IsKeyLocked(key2)
+	require.NoError(t, err)
+	require.False(t, locked)
+
+	fmt.Println("\tdouble lock with same id")
+	fmt.Println("\tlocking ID 1 key 1")
+	err = cm.LockWithKey(id1, key1)
+	require.NoError(t, err, "Unexpected error in LockWithKey(id1,key1)")
+
+	go func() {
+		time.Sleep(1 * time.Second)
+		// Second lock below will block until this unlock (because of same ID)
+		fmt.Println("\tunlocking key 1")
+		err := cm.UnlockWithKey(key1)
+		require.NoError(t, err, "Unexpected error from UnlockWithKey(key1)")
+	}()
+	fmt.Println("\tlocking ID 1 key 2")
+	err = cm.LockWithKey(id1, key2)
+	require.NoError(t, err, "Unexpected error in LockWithKey(id1,key2)")
+
+	fmt.Println("\tunlocking key 2")
+	err = cm.UnlockWithKey(key2)
+	require.NoError(t, err, "Unexpected error in UnlockWithKey(key2)")
+
+	fmt.Println("\tdouble lock with same key")
+	fmt.Println("\tlocking ID 1 key 1")
+	err = cm.LockWithKey(id1, key1)
+	require.NoError(t, err, "Unexpected error in LockWithKey(id1,key1)")
+
+	go func() {
+		time.Sleep(1 * time.Second)
+		// Second lock below will block until this unlock (because of same key)
+		fmt.Println("\tunlocking key 1")
+		err := cm.UnlockWithKey(key1)
+		require.NoError(t, err, "Unexpected error from UnlockWithKey(key1)")
+	}()
+	fmt.Println("\tlocking ID 2 key 1")
+	err = cm.LockWithKey(id2, key1)
+	require.NoError(t, err, "Unexpected error in LockWithKey(id2,key1)")
+
+	fmt.Println("\tunlocking key 1")
+	err = cm.UnlockWithKey(key1)
+	require.NoError(t, err, "Unexpected error in UnlockWithKey(key1)")
+
+	fmt.Println("\tlockExpiration")
+
+	var lockTimedout bool
+	fatalLockCb := func(format string, args ...interface{}) {
+		fmt.Println("\tLock timeout called.")
+		lockTimedout = true
+		err := cm.UnlockWithKey(key1)
+		require.NoError(t, err, "Unexpected error from Unlock")
+	}
+	SetFatalCb(fatalLockCb)
+
+	// Check lock expiration
+	err = cm.LockWithKey(id1, key1)
+	require.NoError(t, err, "Unexpected error in lock")
+	time.Sleep((v2DefaultK8sLockRefreshDuration * 3) + time.Second)
+	require.True(t, lockTimedout, "Lock hold timeout not triggered")
+
+	locked, owner, err = cm.IsKeyLocked(key1)
+	require.NoError(t, err)
+	require.False(t, locked)
+
+	err = cm.LockWithKey(id2, key1)
+	require.NoError(t, err, "Lock should have expired")
+	err = cm.UnlockWithKey(key1)
+	require.NoError(t, err, "Unexpected no error in unlock")
+	err = cm.Delete()
+	require.NoError(t, err, "Unexpected error on Delete")
+}

--- a/k8s/core/configmap/types.go
+++ b/k8s/core/configmap/types.go
@@ -1,0 +1,113 @@
+package configmap
+
+import (
+	"errors"
+	"regexp"
+	"sync"
+	"time"
+)
+
+const (
+	// DefaultK8sLockAttempts is the number of times to try taking the lock before failing.
+	// It defaults to 300, the same number for a kvdb lock.
+	DefaultK8sLockAttempts = 300
+	// DefaultK8sLockTimeout is time duration within which a lock should be released
+	// else it assumes that the node is stuck and panics.
+	DefaultK8sLockTimeout = 3 * time.Minute
+	// v1DefaultK8sLockTTL is the time duration after which the lock will expire
+	v1DefaultK8sLockTTL = 16 * time.Second
+	// v1DefaultK8sLockRefreshDuration is the time duration after which a lock is refreshed
+	v1DefaultK8sLockRefreshDuration = 8 * time.Second
+	// v2DefaultK8sLockTTL is the time duration after which the lock will expire
+	v2DefaultK8sLockTTL = 60 * time.Second
+	// v2DefaultK8sLockRefreshDuration is the time duration after which a lock is refreshed
+	v2DefaultK8sLockRefreshDuration = 20 * time.Second
+	// k8sSystemNamespace is the namespace in which we create the ConfigMap
+	k8sSystemNamespace = "kube-system"
+
+	// ***********************
+	//   ConfigMap Lock Keys
+	// ***********************
+
+	// pxOwnerKey is key which indicates the node holding the ConfigMap lock.
+	// This is specifically for the deprecated Lock and Unlock methods.
+	pxOwnerKey = "px-owner"
+	// pxExpirationKey is the key which indicates the time at which the
+	// current lock will expire.
+	// This is specifically for the deprecated Lock and Unlock methods.
+	pxExpirationKey = "px-expiration"
+
+	// pxLockKey is the key which stores the lock data. The data in this key is stored in JSON as an array of lockData
+	// objects.
+	pxLockKey = "px-lock"
+
+	lockSleepDuration     = 1 * time.Second
+	configMapUserLabelKey = "user"
+	maxConflictRetries    = 3
+)
+
+var (
+	// ErrConfigMapLocked is returned when the ConfigMap is locked
+	ErrConfigMapLocked = errors.New("ConfigMap is locked")
+	fatalCb            FatalCb
+	configMapNameRegex = regexp.MustCompile("[^a-zA-Z0-9]+")
+)
+
+// FatalCb is a callback function which will be executed if the Lock
+// routine encounters a panic situation
+type FatalCb func(format string, args ...interface{})
+
+type configMap struct {
+	name                string
+	kLockV1             k8sLock
+	kLocksV2Mutex       sync.Mutex
+	kLocksV2            map[string]*k8sLock
+	lockTimeout         time.Duration
+	lockAttempts        uint
+	lockRefreshDuration time.Duration
+	lockK8sLockTTL      time.Duration
+}
+
+type k8sLock struct {
+	done     chan struct{}
+	unlocked bool
+	id       string
+	sync.Mutex
+}
+
+// ConfigMap is an interface that provides a set of APIs over a single
+// k8s configmap object. The data in the configMap is managed as a map of string
+// to string
+type ConfigMap interface {
+	// Lock locks a configMap where id is the identification of
+	// the holder of the lock.
+	Lock(id string) error
+	// LockWithKey locks a configMap where owner is the identification
+	// of the holder of the lock and key is the specific lock to take.
+	LockWithKey(owner, key string) error
+	// Unlock unlocks the configMap.
+	Unlock() error
+	// UnlockWithKey unlocks the given key in the configMap.
+	UnlockWithKey(key string) error
+	// IsKeyLocked returns if the given key is locked, and if so, by which owner.
+	IsKeyLocked(key string) (bool, string, error)
+
+	// Patch updates only the keys provided in the input map.
+	// It does not replace the complete map
+	Patch(data map[string]string) error
+	// Update overwrites the data of the configmap
+	Update(data map[string]string) error
+	// Get returns the contents of the configMap
+	Get() (map[string]string, error)
+	// Delete deletes the configMap
+	Delete() error
+}
+
+// lockData structs are serialized into JSON and stored as a list inside a ConfigMap.
+// Each lockData struct contains the owner (usually which node took the lock), key
+// (which specific lock it's taking), and an expiration time after which the lock is invalid.
+type lockData struct {
+	Owner      string    `json:"owner"`
+	Key        string    `json:"key"`
+	Expiration time.Time `json:"expiration"`
+}


### PR DESCRIPTION
Signed-off-by: Naveen Revanna <nrevanna@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Config map lock uses config map as a locking mechanism. 

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

