### PR TITLE
Fixes ValidatePVCsForStatefulSet when apps have multiple PVCs in spec, and addresses flaky ConfigMap lock timing test

### DIFF
--- a/k8s/apps/statefulsets.go
+++ b/k8s/apps/statefulsets.go
@@ -271,8 +271,9 @@ func (c *Client) ValidatePVCsForStatefulSet(ss *appsv1.StatefulSet, timeout, ret
 			return nil, true, err
 		}
 
-		if len(pvcList.Items) < int(*ss.Spec.Replicas) {
-			return nil, true, fmt.Errorf("Expected PVCs: %v, Actual: %v", *ss.Spec.Replicas, len(pvcList.Items))
+		expectedPVCCount := len(ss.Spec.VolumeClaimTemplates) * int(*ss.Spec.Replicas)
+		if len(pvcList.Items) < expectedPVCCount {
+			return nil, true, fmt.Errorf("Expected PVCs: %v, Actual: %v", expectedPVCCount, len(pvcList.Items))
 		}
 
 		for _, pvc := range pvcList.Items {

--- a/k8s/core/configmap/configmap_lock_v2_test.go
+++ b/k8s/core/configmap/configmap_lock_v2_test.go
@@ -120,7 +120,7 @@ func TestMultilock(t *testing.T) {
 	// Locking again with same owner should not throw error
 	err = cm.LockWithKey(id1, key1)
 	require.NoError(t, err, "Unexpected error in lock")
-	time.Sleep((v2DefaultK8sLockRefreshDuration * 3) + time.Second)
+	time.Sleep((v2DefaultK8sLockRefreshDuration * 3) + (3 * time.Second))
 	require.True(t, lockTimedout, "Lock hold timeout not triggered")
 
 	// Locking again with expired lock should not throw error


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently if we try to use an app like `fio` which has both a logs and data PVC, this function will exit out of the count check early even if not all PVCs are created since it's only going by number of replicas.

Also fixes a configmap lock test that sometimes didn't wait long enough, probably just due to various factors over the 60 seconds.

**Special notes for your reviewer**:
Just finished testing this change in a torpedo deployment of mine, it counts correctly. ~~Will double check if there's a similar check anywhere else.~~ Just confirmed, this is the only time we check StatefulSet count.