### PR TITLE
pb-2219: adding ListPods api

### DIFF
--- a/k8s/core/pods.go
+++ b/k8s/core/pods.go
@@ -24,6 +24,8 @@ type PodOps interface {
 	CreatePod(pod *corev1.Pod) (*corev1.Pod, error)
 	// UpdatePod updates the given pod
 	UpdatePod(pod *corev1.Pod) (*corev1.Pod, error)
+	// ListPods returns pods from all namespaces matching the given label
+	ListPods(map[string]string) (*corev1.PodList, error)
 	// GetPods returns pods for the given namespace
 	GetPods(string, map[string]string) (*corev1.PodList, error)
 	// GetPodsByNode returns all pods in given namespace and given k8s node name.
@@ -91,6 +93,17 @@ func (c *Client) UpdatePod(pod *corev1.Pod) (*corev1.Pod, error) {
 	}
 
 	return c.kubernetes.CoreV1().Pods(pod.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
+}
+
+// ListPods returns pods from all namespaces matching the given label
+func (c *Client) ListPods(labelSelector map[string]string) (*corev1.PodList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	opts := metav1.ListOptions{
+		LabelSelector: mapToCSV(labelSelector),
+	}
+	return c.kubernetes.CoreV1().Pods("").List(context.TODO(), opts)
 }
 
 // GetPods returns pods for the given namespace


### PR DESCRIPTION
**What this PR does / why we need it**:
```
 pb-2219: adding ListPods api to get list of pods from all namespaces,
    with matching labels.
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-2219

**Special notes for your reviewer**:
Tested the api by calling it in the stork code.
