### PR TITLE
Allow users to set qps and burst rate for sched-ops api calls

### DIFF
--- a/k8s/admissionregistration/admissionregistration.go
+++ b/k8s/admissionregistration/admissionregistration.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/portworx/sched-ops/k8s/common"
 	apiadmissionsclientv1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
 	apiadmissionsclient "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
 
@@ -146,7 +147,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
-
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.admission, err = apiadmissionsclient.NewForConfig(c.config)
 	if err != nil {
 		return err

--- a/k8s/apiextensions/apiextensions.go
+++ b/k8s/apiextensions/apiextensions.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/portworx/sched-ops/k8s/common"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
@@ -139,7 +140,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
-
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.extension, err = apiextensionsclient.NewForConfig(c.config)
 	if err != nil {
 		return err

--- a/k8s/apps/apps.go
+++ b/k8s/apps/apps.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/portworx/sched-ops/k8s/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -153,7 +154,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
-
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.apps, err = appsv1client.NewForConfig(c.config)
 	if err != nil {
 		return err

--- a/k8s/autopilot/autopilot.go
+++ b/k8s/autopilot/autopilot.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	autopilotclientset "github.com/libopenstorage/autopilot-api/pkg/client/clientset/versioned"
+	"github.com/portworx/sched-ops/k8s/common"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -136,7 +137,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
-
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.autopilot, err = autopilotclientset.NewForConfig(c.config)
 	if err != nil {
 		return err

--- a/k8s/batch/batch.go
+++ b/k8s/batch/batch.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/portworx/sched-ops/k8s/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
 	batchv1beta1client "k8s.io/client-go/kubernetes/typed/batch/v1beta1"
@@ -144,7 +145,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
-
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.batch, err = batchv1client.NewForConfig(c.config)
 	if err != nil {
 		return err

--- a/k8s/common/utils.go
+++ b/k8s/common/utils.go
@@ -1,0 +1,32 @@
+package common
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"k8s.io/client-go/rest"
+)
+
+const (
+	QPSRate   = "KUBERNETES_OPS_QPS_RATE"
+	BurstRate = "KUBERNETES_OPS_BURST_RATE"
+)
+
+func SetRateLimiter(config *rest.Config) error {
+	if val := os.Getenv(QPSRate); val != "" {
+		qps, err := strconv.Atoi(val)
+		if err != nil {
+			return fmt.Errorf("invalid qps count specified %v: %v", val, err)
+		}
+		config.QPS = float32(qps)
+	}
+	if val := os.Getenv(BurstRate); val != "" {
+		burst, err := strconv.Atoi(val)
+		if err != nil {
+			return fmt.Errorf("invalid burst count specified %v: %v", val, err)
+		}
+		config.Burst = int(burst)
+	}
+	return nil
+}

--- a/k8s/core/core.go
+++ b/k8s/core/core.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/portworx/sched-ops/k8s/common"
 	"github.com/portworx/sched-ops/task"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -204,7 +205,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
-
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.kubernetes, err = kubernetes.NewForConfig(c.config)
 	if err != nil {
 		return err

--- a/k8s/dynamic/dynamic.go
+++ b/k8s/dynamic/dynamic.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/portworx/sched-ops/k8s/common"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -223,7 +224,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
-
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.client, err = dynamic.NewForConfig(c.config)
 	if err != nil {
 		return err

--- a/k8s/externalsnapshotter/externalsnapshotter.go
+++ b/k8s/externalsnapshotter/externalsnapshotter.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned/typed/volumesnapshot/v1beta1"
+	"github.com/portworx/sched-ops/k8s/common"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -138,7 +139,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
-
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.client, err = v1beta1.NewForConfig(c.config)
 	if err != nil {
 		return err

--- a/k8s/externalstorage/externalstorage.go
+++ b/k8s/externalstorage/externalstorage.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	snapclient "github.com/kubernetes-incubator/external-storage/snapshot/pkg/client"
+	"github.com/portworx/sched-ops/k8s/common"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -135,7 +136,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
-
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.snap, _, err = snapclient.NewClient(c.config)
 	if err != nil {
 		return err

--- a/k8s/kdmp/kdmp.go
+++ b/k8s/kdmp/kdmp.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	kdmpclientset "github.com/portworx/kdmp/pkg/client/clientset/versioned"
+	"github.com/portworx/sched-ops/k8s/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -152,7 +153,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
-
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.kube, err = kubernetes.NewForConfig(c.config)
 	if err != nil {
 		return err

--- a/k8s/networking/networking.go
+++ b/k8s/networking/networking.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/portworx/sched-ops/k8s/common"
 	networkingv1betaclient "k8s.io/client-go/kubernetes/typed/networking/v1beta1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -135,7 +136,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
-
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.networking, err = networkingv1betaclient.NewForConfig(c.config)
 	if err != nil {
 		return err

--- a/k8s/openshift/openshift.go
+++ b/k8s/openshift/openshift.go
@@ -8,6 +8,7 @@ import (
 	ocpclientset "github.com/openshift/client-go/apps/clientset/versioned"
 	ocpconfigclientset "github.com/openshift/client-go/config/clientset/versioned"
 	ocpsecurityclientset "github.com/openshift/client-go/security/clientset/versioned"
+	"github.com/portworx/sched-ops/k8s/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -172,7 +173,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
-
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.kube, err = kubernetes.NewForConfig(c.config)
 	if err != nil {
 		return err

--- a/k8s/operator/operator.go
+++ b/k8s/operator/operator.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	ostclientset "github.com/libopenstorage/operator/pkg/client/clientset/versioned"
+	"github.com/portworx/sched-ops/k8s/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -139,7 +140,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
-
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.ost, err = ostclientset.NewForConfig(c.config)
 	if err != nil {
 		return err

--- a/k8s/policy/policy.go
+++ b/k8s/policy/policy.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/portworx/sched-ops/k8s/common"
 	policyv1beta1client "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -136,7 +137,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
-
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.policy, err = policyv1beta1client.NewForConfig(c.config)
 	if err != nil {
 		return err

--- a/k8s/prometheus/prometheus.go
+++ b/k8s/prometheus/prometheus.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/portworx/sched-ops/k8s/common"
 	prometheusclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
@@ -143,7 +144,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
-
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.prometheus, err = prometheusclient.NewForConfig(c.config)
 	if err != nil {
 		return err

--- a/k8s/rbac/rbac.go
+++ b/k8s/rbac/rbac.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/portworx/sched-ops/k8s/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	"k8s.io/client-go/rest"
@@ -141,7 +142,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
-
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.rbac, err = rbacv1client.NewForConfig(c.config)
 	if err != nil {
 		return err

--- a/k8s/storage/storage.go
+++ b/k8s/storage/storage.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/portworx/sched-ops/k8s/common"
 	storagev1client "k8s.io/client-go/kubernetes/typed/storage/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -136,6 +137,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.storage, err = storagev1client.NewForConfig(c.config)
 	if err != nil {
 		return err

--- a/k8s/stork/stork.go
+++ b/k8s/stork/stork.go
@@ -10,6 +10,7 @@ import (
 	snapclient "github.com/kubernetes-incubator/external-storage/snapshot/pkg/client"
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	storkclientset "github.com/libopenstorage/stork/pkg/client/clientset/versioned"
+	"github.com/portworx/sched-ops/k8s/common"
 	"github.com/portworx/sched-ops/task"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -175,7 +176,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
-
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.kube, err = kubernetes.NewForConfig(c.config)
 	if err != nil {
 		return err

--- a/k8s/talisman/talisman.go
+++ b/k8s/talisman/talisman.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/portworx/sched-ops/k8s/common"
 	talismanclientset "github.com/portworx/talisman/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
@@ -138,7 +139,10 @@ func (c *Client) loadClient() error {
 	}
 
 	var err error
-
+	err = common.SetRateLimiter(c.config)
+	if err != nil {
+		return err
+	}
 	c.talisman, err = talismanclientset.NewForConfig(c.config)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows caller to set qps and burst rate for sched-ops api calls via env variables

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

