### PR TITLE
PWX-27654: CSR support

### DIFF
--- a/k8s/core/csr.go
+++ b/k8s/core/csr.go
@@ -1,0 +1,158 @@
+package core
+
+import (
+	"context"
+	"time"
+
+	certv1 "k8s.io/api/certificates/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+)
+
+// CertificateOps is an interface to perform k8s Certificate operations
+type CertificateOps interface {
+	CreateCertificateSigningRequests(csr []byte, name string, labs map[string]string, signer string, dur *time.Duration, usages []certv1.KeyUsage) (*certv1.CertificateSigningRequest, error)
+	UpdateCertificateSigningRequests(csr []byte, name string, labs map[string]string, signer string, dur *time.Duration, usages []certv1.KeyUsage) (*certv1.CertificateSigningRequest, error)
+	ListCertificateSigningRequests(labels map[string]string) (*certv1.CertificateSigningRequestList, error)
+	GetCertificateSigningRequest(name string) (*certv1.CertificateSigningRequest, error)
+	DeleteCertificateSigningRequests(name string) error
+	WatchCertificateSigningRequests(csr *certv1.CertificateSigningRequest, fn WatchFunc) error
+}
+
+// CreateCertificateSigningRequests creates CSR
+func (c *Client) CreateCertificateSigningRequests(
+	csrData []byte,
+	name string,
+	labels map[string]string,
+	signerName string,
+	requestedDuration *time.Duration,
+	usages []certv1.KeyUsage,
+) (*certv1.CertificateSigningRequest, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	csr := getCSR(csrData, name, labels, signerName, requestedDuration, usages)
+
+	return c.kubernetes.CertificatesV1().CertificateSigningRequests().Create(
+		context.TODO(),
+		csr,
+		metav1.CreateOptions{},
+	)
+}
+
+// UpdateCertificateSigningRequests updates existing CSR
+func (c *Client) UpdateCertificateSigningRequests(
+	csrData []byte,
+	name string,
+	labels map[string]string,
+	signerName string,
+	requestedDuration *time.Duration,
+	usages []certv1.KeyUsage,
+) (*certv1.CertificateSigningRequest, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	csr := getCSR(csrData, name, labels, signerName, requestedDuration, usages)
+
+	return c.kubernetes.CertificatesV1().CertificateSigningRequests().Update(
+		context.TODO(),
+		csr,
+		metav1.UpdateOptions{},
+	)
+}
+
+func getCSR(
+	csrData []byte,
+	name string,
+	labels map[string]string,
+	signerName string,
+	requestedDuration *time.Duration,
+	usages []certv1.KeyUsage,
+) *certv1.CertificateSigningRequest {
+	csr := &certv1.CertificateSigningRequest{
+		// Username, UID, Groups will be injected by API server.
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CertificateSigningRequest",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Spec: certv1.CertificateSigningRequestSpec{
+			Request:    csrData,
+			Usages:     usages,
+			SignerName: signerName,
+		},
+	}
+	if len(csr.Name) == 0 {
+		csr.GenerateName = "csr-"
+	}
+	if requestedDuration != nil {
+		i := int32(*requestedDuration / time.Second)
+		csr.Spec.ExpirationSeconds = &i
+	}
+	return csr
+}
+
+// ListCertificateSigningRequests lists the existing certificate signing requests
+func (c *Client) ListCertificateSigningRequests(labels map[string]string) (*certv1.CertificateSigningRequestList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.kubernetes.CertificatesV1().CertificateSigningRequests().List(
+		context.TODO(),
+		metav1.ListOptions{
+			LabelSelector: mapToCSV(labels),
+		})
+}
+
+// GetCertificateSigningRequest retrieves a named certificate request
+func (c *Client) GetCertificateSigningRequest(name string) (*certv1.CertificateSigningRequest, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.kubernetes.CertificatesV1().CertificateSigningRequests().Get(
+		context.TODO(),
+		name,
+		metav1.GetOptions{},
+	)
+}
+
+// DeleteCertificateSigningRequests deletes the given CSR
+func (c *Client) DeleteCertificateSigningRequests(name string) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+
+	return c.kubernetes.CertificatesV1().CertificateSigningRequests().Delete(
+		context.TODO(),
+		name,
+		metav1.DeleteOptions{},
+	)
+}
+
+// WatchCertificateSigningRequests reports changes on the requested CSR
+// - CAUTION: Must populate at least csr.Name
+func (c *Client) WatchCertificateSigningRequests(csr *certv1.CertificateSigningRequest, fn WatchFunc) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+
+	listOptions := metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("metadata.name", csr.Name).String(),
+		Watch:         true,
+	}
+
+	watchInterface, err := c.kubernetes.CertificatesV1().CertificateSigningRequests().Watch(context.TODO(), listOptions)
+	if err != nil {
+		return err
+	}
+
+	// fire off watch function
+	go c.handleWatch(watchInterface, csr, "", fn, listOptions)
+	return nil
+}

--- a/k8s/core/events.go
+++ b/k8s/core/events.go
@@ -16,6 +16,8 @@ import (
 type EventOps interface {
 	// CreateEvent puts an event into k8s etcd
 	CreateEvent(event *corev1.Event) (*corev1.Event, error)
+	// CreateEvent puts an event into k8s etcd
+	UpdateEvent(event *corev1.Event) (*corev1.Event, error)
 	// ListEvents retrieves all events registered with kubernetes
 	ListEvents(namespace string, opts metav1.ListOptions) (*corev1.EventList, error)
 }
@@ -26,6 +28,14 @@ func (c *Client) CreateEvent(event *corev1.Event) (*corev1.Event, error) {
 		return nil, err
 	}
 	return c.kubernetes.CoreV1().Events(event.Namespace).Create(context.TODO(), event, metav1.CreateOptions{})
+}
+
+// UpdateEvent updates an event from k8s etcd
+func (c *Client) UpdateEvent(event *corev1.Event) (*corev1.Event, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.kubernetes.CoreV1().Events(event.Namespace).Update(context.TODO(), event, metav1.UpdateOptions{})
 }
 
 // ListEvents retrieves all events registered with kubernetes

--- a/k8s/core/events.go
+++ b/k8s/core/events.go
@@ -16,7 +16,7 @@ import (
 type EventOps interface {
 	// CreateEvent puts an event into k8s etcd
 	CreateEvent(event *corev1.Event) (*corev1.Event, error)
-	// CreateEvent puts an event into k8s etcd
+	// UpdateEvent updates an event in k8s etcd
 	UpdateEvent(event *corev1.Event) (*corev1.Event, error)
 	// ListEvents retrieves all events registered with kubernetes
 	ListEvents(namespace string, opts metav1.ListOptions) (*corev1.EventList, error)
@@ -30,7 +30,7 @@ func (c *Client) CreateEvent(event *corev1.Event) (*corev1.Event, error) {
 	return c.kubernetes.CoreV1().Events(event.Namespace).Create(context.TODO(), event, metav1.CreateOptions{})
 }
 
-// UpdateEvent updates an event from k8s etcd
+// UpdateEvent updates an event in k8s etcd
 func (c *Client) UpdateEvent(event *corev1.Event) (*corev1.Event, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Zoran Rajic <zrajic@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This change adds support for Kubernetes CSR (Certificate Signing Requests).

Additionally, adding the `UpdateEvent()` to allow updating pre-existing K8s Events

**Which issue(s) this PR fixes** (optional)
Closes # PWX-27654

**Special notes for your reviewer**:
Required for "auto-SSL" setup of Portworx in K8s environments.