### PR TITLE
PTX-14423 Fix lint errors

### DIFF
--- a/k8s/admissionregistration/mutationwebhooks_v1beta1.go
+++ b/k8s/admissionregistration/mutationwebhooks_v1beta1.go
@@ -27,7 +27,7 @@ func (c *Client) GetMutatingWebhookConfigurationV1beta1(name string) (*hook.Muta
 	return c.admission.MutatingWebhookConfigurations().Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-// GetMutatingWebhookConfigurationV1beta1 creates given MutatingWebhookConfiguration
+// CreateMutatingWebhookConfigurationV1beta1 creates given MutatingWebhookConfiguration
 func (c *Client) CreateMutatingWebhookConfigurationV1beta1(cfg *hook.MutatingWebhookConfiguration) (*hook.MutatingWebhookConfiguration, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err

--- a/k8s/batch/cron.go
+++ b/k8s/batch/cron.go
@@ -26,6 +26,7 @@ type CronOps interface {
 	ListCronJobs(namespace string, filterOptions metav1.ListOptions) (*v1.CronJobList, error)
 }
 
+// NamespaceDefault is a default namespace for cronjob
 var NamespaceDefault = "default"
 
 // CreateCronJob creates the given cronJob

--- a/k8s/common/utils.go
+++ b/k8s/common/utils.go
@@ -9,19 +9,20 @@ import (
 )
 
 const (
-	QPSRate   = "KUBERNETES_OPS_QPS_RATE"
-	BurstRate = "KUBERNETES_OPS_BURST_RATE"
+	qPSRate   = "KUBERNETES_OPS_QPS_RATE"
+	burstRate = "KUBERNETES_OPS_BURST_RATE"
 )
 
+// SetRateLimiter sets rate limiter
 func SetRateLimiter(config *rest.Config) error {
-	if val := os.Getenv(QPSRate); val != "" {
+	if val := os.Getenv(qPSRate); val != "" {
 		qps, err := strconv.Atoi(val)
 		if err != nil {
 			return fmt.Errorf("invalid qps count specified %v: %v", val, err)
 		}
 		config.QPS = float32(qps)
 	}
-	if val := os.Getenv(BurstRate); val != "" {
+	if val := os.Getenv(burstRate); val != "" {
 		burst, err := strconv.Atoi(val)
 		if err != nil {
 			return fmt.Errorf("invalid burst count specified %v: %v", val, err)

--- a/k8s/core/events.go
+++ b/k8s/core/events.go
@@ -53,6 +53,7 @@ type RecorderOps interface {
 	RecordEvent(source v1.EventSource, object runtime.Object, eventtype, reason, message string)
 }
 
+// RecordEvent records an event into k8s using client-go's EventRecorder inteface
 func (c *Client) RecordEvent(source v1.EventSource, object runtime.Object, eventtype, reason, message string) {
 	if err := c.initClient(); err != nil {
 		return

--- a/k8s/core/limitrange.go
+++ b/k8s/core/limitrange.go
@@ -71,6 +71,7 @@ func (c *Client) DeleteLimitRange(name, namespace string) error {
 	})
 }
 
+// WatchLimitRange changes and callback fn
 func (c *Client) WatchLimitRange(limitrange *corev1.LimitRange, fn WatchFunc) error {
 	if err := c.initClient(); err != nil {
 		return err

--- a/k8s/core/persistentvolumeclaims.go
+++ b/k8s/core/persistentvolumeclaims.go
@@ -218,7 +218,7 @@ func (c *Client) GetPersistentVolumes() (*corev1.PersistentVolumeList, error) {
 	return c.kubernetes.CoreV1().PersistentVolumes().List(context.TODO(), metav1.ListOptions{})
 }
 
-// UpdatePersistentVolumeClaim updates an existing persistent volume claim
+// UpdatePersistentVolume updates an existing persistent volume claim
 func (c *Client) UpdatePersistentVolume(pv *corev1.PersistentVolume) (*corev1.PersistentVolume, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err

--- a/k8s/core/secrets.go
+++ b/k8s/core/secrets.go
@@ -103,6 +103,7 @@ func (c *Client) DeleteSecret(name, namespace string) error {
 	})
 }
 
+// WatchSecret changes and callback fn
 func (c *Client) WatchSecret(secret *v1.Secret, fn WatchFunc) error {
 	if err := c.initClient(); err != nil {
 		return err

--- a/k8s/networking/ingress.go
+++ b/k8s/networking/ingress.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Ops is an interface to perform kubernetes related operations on the crd resources.
+// IngressOps is an interface to perform kubernetes related operations on the crd resources.
 type IngressOps interface {
 	// CreateIngress creates the given ingress
 	CreateIngress(ingress *v1beta1.Ingress) (*v1beta1.Ingress, error)
@@ -25,6 +25,7 @@ type IngressOps interface {
 	ValidateIngress(ingress *v1beta1.Ingress, timeout, retryInterval time.Duration) error
 }
 
+// NamespaceDefault default namespace for ingress
 var NamespaceDefault = "default"
 
 // CreateIngress creates the given ingress


### PR DESCRIPTION
Fix `make lint` errors
```
66.14s$ make lint
golint `go list ./...`
/home/travis/gopath/src/github.com/portworx/sched-ops/k8s/admissionregistration/mutationwebhooks_v1beta1.go:30:1: comment on exported method Client.CreateMutatingWebhookConfigurationV1beta1 should be of the form "CreateMutatingWebhookConfigurationV1beta1 ..."
/home/travis/gopath/src/github.com/portworx/sched-ops/k8s/batch/cron.go:29:5: exported var NamespaceDefault should have comment or be unexported
/home/travis/gopath/src/github.com/portworx/sched-ops/k8s/common/utils.go:12:2: exported const QPSRate should have comment (or a comment on this block) or be unexported
/home/travis/gopath/src/github.com/portworx/sched-ops/k8s/common/utils.go:16:1: exported function SetRateLimiter should have comment or be unexported
/home/travis/gopath/src/github.com/portworx/sched-ops/k8s/core/events.go:56:1: exported method Client.RecordEvent should have comment or be unexported
/home/travis/gopath/src/github.com/portworx/sched-ops/k8s/core/limitrange.go:74:1: exported method Client.WatchLimitRange should have comment or be unexported
/home/travis/gopath/src/github.com/portworx/sched-ops/k8s/core/persistentvolumeclaims.go:221:1: comment on exported method Client.UpdatePersistentVolume should be of the form "UpdatePersistentVolume ..."
/home/travis/gopath/src/github.com/portworx/sched-ops/k8s/core/secrets.go:106:1: exported method Client.WatchSecret should have comment or be unexported
/home/travis/gopath/src/github.com/portworx/sched-ops/k8s/networking/ingress.go:14:1: comment on exported type IngressOps should be of the form "IngressOps ..." (with optional leading article)
/home/travis/gopath/src/github.com/portworx/sched-ops/k8s/networking/ingress.go:28:5: exported var NamespaceDefault should have comment or be unexported
```

Signed-off-by: nikolaypopov <nikolay.popov86@gmail.com>