### PR TITLE
PWX-28162_pt2: Add CSR update API call

### DIFF
--- a/k8s/core/csr.go
+++ b/k8s/core/csr.go
@@ -158,6 +158,7 @@ func (c *Client) WatchCertificateSigningRequests(csr *certv1.CertificateSigningR
 	return nil
 }
 
+// CertificateSigningRequestsUpdateApproval used to approve or decline the CSR
 func (c *Client) CertificateSigningRequestsUpdateApproval(
 	name string,
 	csr *certv1.CertificateSigningRequest,

--- a/k8s/core/csr.go
+++ b/k8s/core/csr.go
@@ -17,6 +17,7 @@ type CertificateOps interface {
 	GetCertificateSigningRequest(name string) (*certv1.CertificateSigningRequest, error)
 	DeleteCertificateSigningRequests(name string) error
 	WatchCertificateSigningRequests(csr *certv1.CertificateSigningRequest, fn WatchFunc) error
+	CertificateSigningRequestsUpdateApproval(name string, csr *certv1.CertificateSigningRequest) (*certv1.CertificateSigningRequest, error)
 }
 
 // CreateCertificateSigningRequests creates CSR
@@ -155,4 +156,20 @@ func (c *Client) WatchCertificateSigningRequests(csr *certv1.CertificateSigningR
 	// fire off watch function
 	go c.handleWatch(watchInterface, csr, "", fn, listOptions)
 	return nil
+}
+
+func (c *Client) CertificateSigningRequestsUpdateApproval(
+	name string,
+	csr *certv1.CertificateSigningRequest,
+) (*certv1.CertificateSigningRequest, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.kubernetes.CertificatesV1().CertificateSigningRequests().UpdateApproval(
+		context.TODO(),
+		name,
+		csr,
+		metav1.UpdateOptions{},
+	)
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

Adding a call to update approval-status on CertificateSigningRequest (CSR) objects
* this call is needed by the PX-Operator, to automatically approve the CSR objects posted by the OCI-Monitor

**Which issue(s) this PR fixes** (optional)
Closes #  PWX-28162 (part 2)

**Special notes for your reviewer**:

