### PR TITLE
pb-3443: Added check for pvc to be present in the mount list of container for getPodsUsingPVCWithListOptions api

### DIFF
--- a/k8s/core/pods.go
+++ b/k8s/core/pods.go
@@ -217,8 +217,16 @@ func (c *Client) getPodsUsingPVCWithListOptions(pvcName, pvcNamespace string, op
 	for _, p := range pods.Items {
 		for _, v := range p.Spec.Volumes {
 			if v.PersistentVolumeClaim != nil && v.PersistentVolumeClaim.ClaimName == pvcName {
-				retList = append(retList, p)
-				break
+				// Along PVC present in the volume list, we also checking whether any of the container in the
+				// pod is really using it by mount them.
+				for _, container := range p.Spec.Containers {
+					for _, mount := range container.VolumeMounts {
+						if mount.Name == v.Name {
+							retList = append(retList, p)
+							break
+						}
+					}
+				}
 			}
 		}
 	}

--- a/k8s/storage/storage.go
+++ b/k8s/storage/storage.go
@@ -18,7 +18,7 @@ var (
 
 // Ops is an interface to perform kubernetes related operations on the core resources.
 type Ops interface {
-	StorageClassOps
+	ScOps
 	VolumeAttachmentOps
 
 	// SetConfig sets the config and resets the client

--- a/k8s/storage/storageclass.go
+++ b/k8s/storage/storageclass.go
@@ -8,8 +8,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-// StorageClassOps is an interface to perform k8s storage class operations
-type StorageClassOps interface {
+// ScOps is an interface to perform k8s storage class operations
+type ScOps interface {
 	// GetStorageClasses returns all storageClasses that match given optional label selector
 	GetStorageClasses(labelSelector map[string]string) (*storagev1.StorageClassList, error)
 	// GetStorageClass returns the storage class for the give namme


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-3443: Added check for pvc to be present in the mount list of container for getPodsUsingPVCWithListOptions api
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-3443

**Special notes for your reviewer**:
**Testing:**
Validate following cases:
**Usecase1:**
- In a mysql deployment, had the pvc listed both in the volume list and mount list.
- With this deployment, verified that correct pod list was listed and in the generic backup, it was taking live backup.
- Verified that job pods are created in the kube-system.

**Usecase2:**
- In a mysql deployment, had the pvc listed only in the volume list and not in the mount list.
- With this deployment, verified that pod was not return by getPodsUsingPVCWithListOptions api and generic backup was taking non-live backup.
- Verified that kdmp job pods are created in pvc namespace.
