### PR TITLE
PWX-26175_r2: Adding RunCommandInPodEx

### DIFF
--- a/k8s/core/pods.go
+++ b/k8s/core/pods.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	"github.com/portworx/sched-ops/k8s/common"
@@ -70,13 +71,25 @@ type PodOps interface {
 	// RunCommandInPod runs given command in the given pod
 	RunCommandInPod(cmds []string, podName, containerName, namespace string) (string, error)
 	// RunCommandInPodEx is extended version of RunCommandInPod
-	RunCommandInPodEx(cmds []string, podName, containerName, namespace string, useTTY bool, stdin io.Reader, stdout, stderr io.Writer) error
+	RunCommandInPodEx(*RunCommandInPodExRequest) error
 	// ValidatePod validates the given pod if it's ready
 	ValidatePod(pod *corev1.Pod, timeout, retryInterval time.Duration) error
 	// WatchPods sets up a watcher that listens for the changes to pods in given namespace
 	WatchPods(namespace string, fn WatchFunc, listOptions metav1.ListOptions) error
 	// GetPodLogs returns the logs of a POD as a string
 	GetPodLog(podName string, namespace string, podLogOptions *corev1.PodLogOptions) (string, error)
+}
+
+// RunCommandInPodExRequest is a request structure for the RunCommandInPodEx func
+type RunCommandInPodExRequest struct {
+	Command       []string
+	PODName       string
+	ContainerName string
+	Namespace     string
+	UseTTY        bool
+	Stdin         io.Reader
+	Stdout        io.Writer
+	Stderr        io.Writer
 }
 
 // CreatePod creates the given pod.
@@ -446,14 +459,18 @@ func (c *Client) WaitForPodDeletion(uid types.UID, namespace string, timeout tim
 }
 
 // RunCommandInPodEx runs given command in the given pod  (extended syntax)
-func (c *Client) RunCommandInPodEx(cmds []string, podName, containerName, namespace string, useTTY bool, stdin io.Reader, stdout, stderr io.Writer) error {
+func (c *Client) RunCommandInPodEx(req *RunCommandInPodExRequest) error {
+	if c == nil || req == nil {
+		return os.ErrInvalid
+	}
+
 	err := c.initClient()
 	if err != nil {
 		return err
 	}
 
-	if len(containerName) == 0 {
-		pod, err := c.kubernetes.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if len(req.ContainerName) == 0 {
+		pod, err := c.kubernetes.CoreV1().Pods(req.Namespace).Get(context.TODO(), req.PODName, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -462,33 +479,33 @@ func (c *Client) RunCommandInPodEx(cmds []string, podName, containerName, namesp
 			return fmt.Errorf("could not determine which container to use")
 		}
 
-		containerName = pod.Spec.Containers[0].Name
+		req.ContainerName = pod.Spec.Containers[0].Name
 	}
 
-	req := c.kubernetes.CoreV1().RESTClient().Post().
+	post := c.kubernetes.CoreV1().RESTClient().Post().
 		Resource("pods").
-		Name(podName).
-		Namespace(namespace).
+		Name(req.PODName).
+		Namespace(req.Namespace).
 		SubResource("exec")
 
-	req.VersionedParams(&corev1.PodExecOptions{
-		Container: containerName,
-		Command:   cmds,
-		Stdin:     (stdin != nil),
-		Stdout:    (stdout != nil),
-		Stderr:    (stderr != nil),
+	post.VersionedParams(&corev1.PodExecOptions{
+		Container: req.ContainerName,
+		Command:   req.Command,
+		Stdin:     (req.Stdin != nil),
+		Stdout:    (req.Stdout != nil),
+		Stderr:    (req.Stderr != nil),
 	}, scheme.ParameterCodec)
 
-	exec, err := remotecommand.NewSPDYExecutor(c.config, "POST", req.URL())
+	exec, err := remotecommand.NewSPDYExecutor(c.config, "POST", post.URL())
 	if err != nil {
 		return fmt.Errorf("failed to init executor: %v", err)
 	}
 
 	err = exec.Stream(remotecommand.StreamOptions{
-		Stdin:  stdin,
-		Stdout: stdout,
-		Stderr: stderr,
-		Tty:    useTTY,
+		Stdin:  req.Stdin,
+		Stdout: req.Stdout,
+		Stderr: req.Stderr,
+		Tty:    req.UseTTY,
 	})
 
 	return err
@@ -498,7 +515,9 @@ func (c *Client) RunCommandInPodEx(cmds []string, podName, containerName, namesp
 func (c *Client) RunCommandInPod(cmds []string, podName, containerName, namespace string) (string, error) {
 	var execOut, execErr bytes.Buffer
 
-	err := c.RunCommandInPodEx(cmds, podName, containerName, namespace, false, nil, &execOut, &execErr)
+	err := c.RunCommandInPodEx(&RunCommandInPodExRequest{
+		cmds, podName, containerName, namespace, false, nil, &execOut, &execErr,
+	})
 	if err != nil {
 		return execErr.String(), fmt.Errorf("could not execute: %v: %v %v", err, execErr.String(), execOut.String())
 	}

--- a/k8s/core/pods.go
+++ b/k8s/core/pods.go
@@ -69,6 +69,8 @@ type PodOps interface {
 	WaitForPodDeletion(uid types.UID, namespace string, timeout time.Duration) error
 	// RunCommandInPod runs given command in the given pod
 	RunCommandInPod(cmds []string, podName, containerName, namespace string) (string, error)
+	// RunCommandInPodEx is extended version of RunCommandInPod
+	RunCommandInPodEx(cmds []string, podName, containerName, namespace string, useTTY bool, stdin io.Reader, stdout, stderr io.Writer) error
 	// ValidatePod validates the given pod if it's ready
 	ValidatePod(pod *corev1.Pod, timeout, retryInterval time.Duration) error
 	// WatchPods sets up a watcher that listens for the changes to pods in given namespace
@@ -443,26 +445,21 @@ func (c *Client) WaitForPodDeletion(uid types.UID, namespace string, timeout tim
 	return nil
 }
 
-// RunCommandInPod runs given command in the given pod
-func (c *Client) RunCommandInPod(cmds []string, podName, containerName, namespace string) (string, error) {
+// RunCommandInPodEx runs given command in the given pod  (extended syntax)
+func (c *Client) RunCommandInPodEx(cmds []string, podName, containerName, namespace string, useTTY bool, stdin io.Reader, stdout, stderr io.Writer) error {
 	err := c.initClient()
 	if err != nil {
-		return "", err
-	}
-
-	var (
-		execOut bytes.Buffer
-		execErr bytes.Buffer
-	)
-
-	pod, err := c.kubernetes.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
-	if err != nil {
-		return "", err
+		return err
 	}
 
 	if len(containerName) == 0 {
+		pod, err := c.kubernetes.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
 		if len(pod.Spec.Containers) != 1 {
-			return "", fmt.Errorf("could not determine which container to use")
+			return fmt.Errorf("could not determine which container to use")
 		}
 
 		containerName = pod.Spec.Containers[0].Name
@@ -477,21 +474,31 @@ func (c *Client) RunCommandInPod(cmds []string, podName, containerName, namespac
 	req.VersionedParams(&corev1.PodExecOptions{
 		Container: containerName,
 		Command:   cmds,
-		Stdout:    true,
-		Stderr:    true,
+		Stdin:     (stdin != nil),
+		Stdout:    (stdout != nil),
+		Stderr:    (stderr != nil),
 	}, scheme.ParameterCodec)
 
 	exec, err := remotecommand.NewSPDYExecutor(c.config, "POST", req.URL())
 	if err != nil {
-		return "", fmt.Errorf("failed to init executor: %v", err)
+		return fmt.Errorf("failed to init executor: %v", err)
 	}
 
 	err = exec.Stream(remotecommand.StreamOptions{
-		Stdout: &execOut,
-		Stderr: &execErr,
-		Tty:    false,
+		Stdin:  stdin,
+		Stdout: stdout,
+		Stderr: stderr,
+		Tty:    useTTY,
 	})
 
+	return err
+}
+
+// RunCommandInPod runs given command in the given pod  (simplified syntax)
+func (c *Client) RunCommandInPod(cmds []string, podName, containerName, namespace string) (string, error) {
+	var execOut, execErr bytes.Buffer
+
+	err := c.RunCommandInPodEx(cmds, podName, containerName, namespace, false, nil, &execOut, &execErr)
 	if err != nil {
 		return execErr.String(), fmt.Errorf("could not execute: %v: %v %v", err, execErr.String(), execOut.String())
 	}


### PR DESCRIPTION
* adding `RunCommandInPodEx()`, as "extended" version of func that runs arbitrary commands in a POD
  - this version can pass STDIN to the command, also captures STDOUT/STDERR as separate outputs
* the original `RunCommandInPod()` still exists with same params -- but was refactored to use the new "extended" `RunCommandInPodEx()` internally

Signed-off-by: Zoran Rajic <zrajic@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

Needed for integration-tests added into PX-Operator  (see https://github.com/libopenstorage/operator/pull/938)

**Which issue(s) this PR fixes** (optional)
Closes #  PWX-26175  (part 2)

**Special notes for your reviewer**:

See also [operator#938](https://github.com/libopenstorage/operator/pull/938) where we use this func.