### PR TITLE
PB-3588: Add ListNamespaces with labelSelector as string in NamespaceOps

### DIFF
--- a/k8s/core/namespaces.go
+++ b/k8s/core/namespaces.go
@@ -11,6 +11,8 @@ import (
 type NamespaceOps interface {
 	// ListNamespaces returns all the namespaces
 	ListNamespaces(labelSelector map[string]string) (*corev1.NamespaceList, error)
+	// ListNamespacesV2 returns all the namespaces when the labelSlector is a String
+	ListNamespacesV2(labelSelector string) (*corev1.NamespaceList, error)
 	// GetNamespace returns a namespace object for given name
 	GetNamespace(name string) (*corev1.Namespace, error)
 	// CreateNamespace creates a namespace with given name and metadata
@@ -29,6 +31,17 @@ func (c *Client) ListNamespaces(labelSelector map[string]string) (*corev1.Namesp
 
 	return c.kubernetes.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{
 		LabelSelector: mapToCSV(labelSelector),
+	})
+}
+
+// ListNamespacesV2 returns all the namespaces when the labelSlector is a String
+func (c *Client) ListNamespacesV2(labelSelector string) (*corev1.NamespaceList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.kubernetes.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labelSelector,
 	})
 }
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Add ListNamespacesV2 with labelSelector as string in NamespaceOps. To fetch the namespace objects even when the selector has only key.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Note: This PR is raised only for the code review. unit testing is currently in-progress will post status once it is DONE.
