### PR TITLE
PWX-29473: add a function to allow a different lock hold timeout

### DIFF
--- a/k8s/core/configmap/configmap.go
+++ b/k8s/core/configmap/configmap.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
-
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -33,7 +31,7 @@ func New(
 	}
 	data[pxOwnerKey] = ""
 
-	cm := &v1.ConfigMap{
+	cm := &corev1.ConfigMap{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      name,
 			Namespace: k8sSystemNamespace,
@@ -44,7 +42,7 @@ func New(
 
 	if _, err := core.Instance().CreateConfigMap(cm); err != nil &&
 		!k8s_errors.IsAlreadyExists(err) {
-		return nil, fmt.Errorf("Failed to create configmap %v: %v",
+		return nil, fmt.Errorf("failed to create configmap %v: %v",
 			name, err)
 	}
 
@@ -57,12 +55,12 @@ func New(
 	}
 
 	return &configMap{
-		name:                name,
-		lockTimeout:         lockTimeout,
-		kLocksV2:            map[string]*k8sLock{},
-		lockAttempts:        lockAttempts,
-		lockRefreshDuration: v2LockRefreshDuration,
-		lockK8sLockTTL:      v2LockK8sLockTTL,
+		name:                   name,
+		defaultLockHoldTimeout: lockTimeout,
+		kLocksV2:               map[string]*k8sLock{},
+		lockAttempts:           lockAttempts,
+		lockRefreshDuration:    v2LockRefreshDuration,
+		lockK8sLockTTL:         v2LockK8sLockTTL,
 	}, nil
 }
 

--- a/k8s/core/configmap/configmap_lock_v2.go
+++ b/k8s/core/configmap/configmap_lock_v2.go
@@ -357,7 +357,7 @@ func (c *configMap) refreshLock(id, key string) {
 }
 
 func (c *configMap) checkLockTimeout(startTime time.Time, id string) {
-	if c.lockTimeout > 0 && time.Since(startTime) > c.lockTimeout {
+	if c.defaultLockHoldTimeout > 0 && time.Since(startTime) > c.defaultLockHoldTimeout {
 		panicMsg := fmt.Sprintf("Lock timeout triggered for K8s configmap lock key %s", id)
 		if fatalCb != nil {
 			fatalCb(panicMsg)

--- a/k8s/core/configmap/types.go
+++ b/k8s/core/configmap/types.go
@@ -58,14 +58,15 @@ var (
 type FatalCb func(format string, args ...interface{})
 
 type configMap struct {
-	name                string
-	kLockV1             k8sLock
-	kLocksV2Mutex       sync.Mutex
-	kLocksV2            map[string]*k8sLock
-	lockTimeout         time.Duration
-	lockAttempts        uint
-	lockRefreshDuration time.Duration
-	lockK8sLockTTL      time.Duration
+	name                   string
+	kLockV1                k8sLock
+	kLocksV2Mutex          sync.Mutex
+	kLocksV2               map[string]*k8sLock
+	lockHoldTimeoutV1      time.Duration
+	defaultLockHoldTimeout time.Duration
+	lockAttempts           uint
+	lockRefreshDuration    time.Duration
+	lockK8sLockTTL         time.Duration
 }
 
 type k8sLock struct {
@@ -82,6 +83,8 @@ type ConfigMap interface {
 	// Lock locks a configMap where id is the identification of
 	// the holder of the lock.
 	Lock(id string) error
+	// LockWithHoldTimeout similar to Lock but with a different lock hold timeout
+	LockWithHoldTimeout(id string, holdTimeout time.Duration) error
 	// LockWithKey locks a configMap where owner is the identification
 	// of the holder of the lock and key is the specific lock to take.
 	LockWithKey(owner, key string) error


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a LockWithHoldTimeout function to allow caller to specify a different lock hold timeout than what was specified during object creation.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->



**Which issue(s) this PR fixes** (optional)
PWX-29473

**Special notes for your reviewer**:

