### PR TITLE
PWX-29473: use the correct lock hold timeout

### DIFF
--- a/k8s/core/configmap/configmap_lock_v1.go
+++ b/k8s/core/configmap/configmap_lock_v1.go
@@ -155,7 +155,7 @@ func (c *configMap) refreshLockV1(id string) {
 		case <-refresh.C:
 			c.kLockV1.Lock()
 			for !c.kLockV1.unlocked {
-				c.checkLockTimeout(startTime, id)
+				c.checkLockTimeout(c.lockHoldTimeoutV1, startTime, id)
 				currentRefresh = time.Now()
 				if _, err := c.tryLockV1(id, true); err != nil {
 					configMapLog(fn, c.name, "", "", err).Errorf(

--- a/k8s/core/configmap/configmap_lock_v2.go
+++ b/k8s/core/configmap/configmap_lock_v2.go
@@ -332,7 +332,7 @@ func (c *configMap) refreshLock(id, key string) {
 			lock.Lock()
 
 			for !lock.unlocked {
-				c.checkLockTimeout(startTime, id)
+				c.checkLockTimeout(c.defaultLockHoldTimeout, startTime, id)
 				currentRefresh = time.Now()
 				if _, err := c.tryLock(id, key); err != nil {
 					configMapLog(fn, c.name, "", key, err).Errorf(
@@ -356,9 +356,9 @@ func (c *configMap) refreshLock(id, key string) {
 
 }
 
-func (c *configMap) checkLockTimeout(startTime time.Time, id string) {
-	if c.defaultLockHoldTimeout > 0 && time.Since(startTime) > c.defaultLockHoldTimeout {
-		panicMsg := fmt.Sprintf("Lock timeout triggered for K8s configmap lock key %s", id)
+func (c *configMap) checkLockTimeout(holdTimeout time.Duration, startTime time.Time, id string) {
+	if holdTimeout > 0 && time.Since(startTime) > holdTimeout {
+		panicMsg := fmt.Sprintf("Lock hold timeout (%v) triggered for K8s configmap lock key %s", holdTimeout, id)
 		if fatalCb != nil {
 			fatalCb(panicMsg)
 		} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
We were using the default lock hold timeout instead of using the one specified in LockWithHoldTimeout().

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->



**Which issue(s) this PR fixes** (optional)
PWX-29473

**Special notes for your reviewer**:

