### PR TITLE
Updating csi client package with version v6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/portworx/sched-ops
 go 1.19
 
 require (
-	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc7
 	github.com/libopenstorage/autopilot-api v1.3.0
 	github.com/libopenstorage/openstorage v9.4.47+incompatible
@@ -33,11 +32,11 @@ require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
-	github.com/go-openapi/swag v0.19.14 // indirect
+	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/gnostic v0.5.7-v3refs // indirect
+	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
@@ -45,7 +44,7 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
@@ -87,6 +86,8 @@ require (
 )
 
 require github.com/golang/glog v1.0.0 // indirect
+
+require github.com/kubernetes-csi/external-snapshotter/client/v6 v6.2.0
 
 require github.com/google/go-cmp v0.5.9 // indirect
 

--- a/go.sum
+++ b/go.sum
@@ -1013,6 +1013,7 @@ github.com/fatih/structtag v1.0.0/go.mod h1:IKitwq45uXL/yqi5mYghiD3w9H6eTOvI9vnk
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/firefart/nonamedreturns v1.0.4/go.mod h1:TDhe/tjI1BXo48CmYbUduTV7BdIga8MAO/xbKdcVsGI=
+github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -1116,8 +1117,9 @@ github.com/go-openapi/swag v0.17.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/
 github.com/go-openapi/swag v0.17.2/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/kXLo40Tg=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
-github.com/go-openapi/swag v0.19.14 h1:gm3vOOXfiuw5i9p5N9xJvfjvuofpyvLA9Wr6QfK5Fng=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
+github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
+github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-ozzo/ozzo-validation v3.5.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
 github.com/go-redis/redis v6.15.8+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-sql-driver/mysql v0.0.0-20160411075031-7ebe0a500653/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
@@ -1279,8 +1281,9 @@ github.com/google/cel-go v0.12.5/go.mod h1:Jk7ljRzLBhkmiAwBoUxB1sZSCVBAzkqPF25ol
 github.com/google/cel-spec v0.6.0/go.mod h1:Nwjgxy5CbjlPrtCWjeDjUyKMl8w41YBYGjsyDdqk0xA=
 github.com/google/certificate-transparency-go v1.0.21/go.mod h1:QeJfpSbVSfYc7RgB3gJFj9cbuQMMchQxrWXz8Ruopmg=
 github.com/google/certificate-transparency-go v1.1.1/go.mod h1:FDKqPvSXawb2ecErVRrD+nfy23RCzyl7eqVCEmlT1Zs=
-github.com/google/gnostic v0.5.7-v3refs h1:FhTMOKj2VhjpouxvWJAV1TL304uMlb9zcDqkl6cEI54=
 github.com/google/gnostic v0.5.7-v3refs/go.mod h1:73MKFl6jIHelAJNaBGFzt3SPtZULs9dYrGFt8OiIsHQ=
+github.com/google/gnostic v0.6.9 h1:ZK/5VhkoX835RikCHpSUJV9a+S3e1zLh59YnyWeBW+0=
+github.com/google/gnostic v0.6.9/go.mod h1:Nm8234We1lq6iB9OmlgNv3nH91XLLVZHCDayfA3xq+E=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -1714,8 +1717,9 @@ github.com/kubernetes-csi/csi-lib-utils v0.7.0/go.mod h1:bze+2G9+cmoHxN6+WyG1qT4
 github.com/kubernetes-csi/csi-lib-utils v0.11.0/go.mod h1:BmGZZB16L18+9+Lgg9YWwBKfNEHIDdgGfAyuW6p2NV0=
 github.com/kubernetes-csi/csi-test v2.0.0+incompatible/go.mod h1:YxJ4UiuPWIhMBkxUKY5c267DyA0uDZ/MtAimhx/2TA0=
 github.com/kubernetes-csi/csi-test/v3 v3.0.0/go.mod h1:VdIKGnDZHOjg4M5yd0OZICtsoEzdn64d0K33N6dm35Q=
-github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0 h1:ipLtV9ubLEYx42YvwDa12eVPQvjuGZoPdbCozGzVNRc=
 github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0/go.mod h1:YBCo4DoEeDndqvAn6eeu0vWM7QdXmHEeI9cFWplmBys=
+github.com/kubernetes-csi/external-snapshotter/client/v6 v6.2.0 h1:cMM5AB37e9aRGjErygVT6EuBPB6s5a+l95OPERmSlVM=
+github.com/kubernetes-csi/external-snapshotter/client/v6 v6.2.0/go.mod h1:VQVLCPGDX5l6V5PezjlDXLa+SpCbWSVU7B16cFWVVeE=
 github.com/kubernetes-csi/external-snapshotter/v2 v2.0.1/go.mod h1:vUEcwbrEpsQ/rDgaO8WTe1gVIY/4CCj0S4Q+UuOq5wA=
 github.com/kubernetes-csi/external-snapshotter/v2 v2.1.1/go.mod h1:dV5oB3U62KBdlf9ADWkMmjGd3USauqQtwIm2OZb5mqI=
 github.com/kubernetes-sigs/aws-ebs-csi-driver v0.9.0/go.mod h1:9rv0ManDzr35FnHmuDQv+Vms73LGf6qyXlJhbOjqtZc=
@@ -1792,8 +1796,9 @@ github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
-github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/manifoldco/promptui v0.8.0/go.mod h1:n4zTdgP0vr0S3w7/O/g98U+e0gwLScEXGwov2nIKuGQ=
 github.com/maratori/testableexamples v1.0.0/go.mod h1:4rhjL1n20TUTT4vdh3RDqSizKLyXp7K2u6HgraZCGzE=
 github.com/maratori/testpackage v1.1.0/go.mod h1:PeAhzU8qkCwdGEMTEupsHJNlQu2gZopMC6RjbhmHeDc=

--- a/k8s/externalsnapshotter/externalsnapshotter.go
+++ b/k8s/externalsnapshotter/externalsnapshotter.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned/typed/volumesnapshot/v1beta1"
+	v1 "github.com/kubernetes-csi/external-snapshotter/client/v6/clientset/versioned/typed/volumesnapshot/v1"
 	"github.com/portworx/sched-ops/k8s/common"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -42,7 +42,7 @@ func SetInstance(i Ops) {
 }
 
 // New builds a new client for the given config.
-func New(client v1beta1.SnapshotV1beta1Interface) *Client {
+func New(client v1.SnapshotV1Interface) *Client {
 	return &Client{
 		client: client,
 	}
@@ -50,7 +50,7 @@ func New(client v1beta1.SnapshotV1beta1Interface) *Client {
 
 // NewForConfig builds a new client for the given config.
 func NewForConfig(c *rest.Config) (*Client, error) {
-	client, err := v1beta1.NewForConfig(c)
+	client, err := v1.NewForConfig(c)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func NewInstanceFromConfigFile(config string) (Ops, error) {
 type Client struct {
 	config *rest.Config
 
-	client v1beta1.SnapshotV1beta1Interface
+	client v1.SnapshotV1Interface
 }
 
 // SetConfig sets the config and resets the client
@@ -143,7 +143,7 @@ func (c *Client) loadClient() error {
 	if err != nil {
 		return err
 	}
-	c.client, err = v1beta1.NewForConfig(c.config)
+	c.client, err = v1.NewForConfig(c.config)
 	if err != nil {
 		return err
 	}

--- a/k8s/externalsnapshotter/volumesnapshotclasses.go
+++ b/k8s/externalsnapshotter/volumesnapshotclasses.go
@@ -3,26 +3,26 @@ package externalsnapshotter
 import (
 	"context"
 
-	"github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1beta1"
+	v1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // SnapshotClassOps is an interface to perform k8s VolumeSnapshotClass operations
 type SnapshotClassOps interface {
 	// CreateSnapshotClass creates the given snapshot class
-	CreateSnapshotClass(snap *v1beta1.VolumeSnapshotClass) (*v1beta1.VolumeSnapshotClass, error)
+	CreateSnapshotClass(snap *v1.VolumeSnapshotClass) (*v1.VolumeSnapshotClass, error)
 	// GetSnapshotClass returns the snapshot class for given name
-	GetSnapshotClass(name string) (*v1beta1.VolumeSnapshotClass, error)
+	GetSnapshotClass(name string) (*v1.VolumeSnapshotClass, error)
 	// ListSnapshotClasses lists all snapshot classes
-	ListSnapshotClasses() (*v1beta1.VolumeSnapshotClassList, error)
+	ListSnapshotClasses() (*v1.VolumeSnapshotClassList, error)
 	// UpdateSnapshotClass updates the given snapshot class
-	UpdateSnapshotClass(snap *v1beta1.VolumeSnapshotClass) (*v1beta1.VolumeSnapshotClass, error)
+	UpdateSnapshotClass(snap *v1.VolumeSnapshotClass) (*v1.VolumeSnapshotClass, error)
 	// DeleteSnapshotClass deletes the given snapshot class
 	DeleteSnapshotClass(name string) error
 }
 
 // CreateSnapshotClass creates the given snapshot class.
-func (c *Client) CreateSnapshotClass(snap *v1beta1.VolumeSnapshotClass) (*v1beta1.VolumeSnapshotClass, error) {
+func (c *Client) CreateSnapshotClass(snap *v1.VolumeSnapshotClass) (*v1.VolumeSnapshotClass, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
@@ -30,7 +30,7 @@ func (c *Client) CreateSnapshotClass(snap *v1beta1.VolumeSnapshotClass) (*v1beta
 }
 
 // GetSnapshotClass returns the snapshot class for given name
-func (c *Client) GetSnapshotClass(name string) (*v1beta1.VolumeSnapshotClass, error) {
+func (c *Client) GetSnapshotClass(name string) (*v1.VolumeSnapshotClass, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func (c *Client) GetSnapshotClass(name string) (*v1beta1.VolumeSnapshotClass, er
 }
 
 // ListSnapshotClasses lists all snapshot classes
-func (c *Client) ListSnapshotClasses() (*v1beta1.VolumeSnapshotClassList, error) {
+func (c *Client) ListSnapshotClasses() (*v1.VolumeSnapshotClassList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func (c *Client) ListSnapshotClasses() (*v1beta1.VolumeSnapshotClassList, error)
 }
 
 // UpdateSnapshotClass updates the given snapshot class
-func (c *Client) UpdateSnapshotClass(snap *v1beta1.VolumeSnapshotClass) (*v1beta1.VolumeSnapshotClass, error) {
+func (c *Client) UpdateSnapshotClass(snap *v1.VolumeSnapshotClass) (*v1.VolumeSnapshotClass, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}

--- a/k8s/externalsnapshotter/volumesnapshotcontents.go
+++ b/k8s/externalsnapshotter/volumesnapshotcontents.go
@@ -3,26 +3,26 @@ package externalsnapshotter
 import (
 	"context"
 
-	"github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1beta1"
+	v1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // SnapshotContentOps is an interface to perform k8s VolumeSnapshotContent operations
 type SnapshotContentOps interface {
 	// CreateSnapshotContent creates the given snapshot content
-	CreateSnapshotContent(snap *v1beta1.VolumeSnapshotContent) (*v1beta1.VolumeSnapshotContent, error)
+	CreateSnapshotContent(snap *v1.VolumeSnapshotContent) (*v1.VolumeSnapshotContent, error)
 	// GetSnapshotContent returns the snapshot content for given name
-	GetSnapshotContent(name string) (*v1beta1.VolumeSnapshotContent, error)
+	GetSnapshotContent(name string) (*v1.VolumeSnapshotContent, error)
 	// ListSnapshotContents lists all snapshot contents
-	ListSnapshotContents() (*v1beta1.VolumeSnapshotContentList, error)
+	ListSnapshotContents() (*v1.VolumeSnapshotContentList, error)
 	// UpdateSnapshotContent updates the given snapshot content
-	UpdateSnapshotContent(snap *v1beta1.VolumeSnapshotContent) (*v1beta1.VolumeSnapshotContent, error)
+	UpdateSnapshotContent(snap *v1.VolumeSnapshotContent) (*v1.VolumeSnapshotContent, error)
 	// DeleteSnapshotContent deletes the given snapshot content
 	DeleteSnapshotContent(name string) error
 }
 
 // CreateSnapshotContent creates the given snapshot content.
-func (c *Client) CreateSnapshotContent(snap *v1beta1.VolumeSnapshotContent) (*v1beta1.VolumeSnapshotContent, error) {
+func (c *Client) CreateSnapshotContent(snap *v1.VolumeSnapshotContent) (*v1.VolumeSnapshotContent, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
@@ -30,7 +30,7 @@ func (c *Client) CreateSnapshotContent(snap *v1beta1.VolumeSnapshotContent) (*v1
 }
 
 // GetSnapshotContent returns the snapshot content for given name
-func (c *Client) GetSnapshotContent(name string) (*v1beta1.VolumeSnapshotContent, error) {
+func (c *Client) GetSnapshotContent(name string) (*v1.VolumeSnapshotContent, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func (c *Client) GetSnapshotContent(name string) (*v1beta1.VolumeSnapshotContent
 }
 
 // ListSnapshotContents lists all snapshot contents
-func (c *Client) ListSnapshotContents() (*v1beta1.VolumeSnapshotContentList, error) {
+func (c *Client) ListSnapshotContents() (*v1.VolumeSnapshotContentList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func (c *Client) ListSnapshotContents() (*v1beta1.VolumeSnapshotContentList, err
 }
 
 // UpdateSnapshotContent updates the given snapshot content
-func (c *Client) UpdateSnapshotContent(snap *v1beta1.VolumeSnapshotContent) (*v1beta1.VolumeSnapshotContent, error) {
+func (c *Client) UpdateSnapshotContent(snap *v1.VolumeSnapshotContent) (*v1.VolumeSnapshotContent, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}

--- a/k8s/externalsnapshotter/volumesnapshots.go
+++ b/k8s/externalsnapshotter/volumesnapshots.go
@@ -3,26 +3,26 @@ package externalsnapshotter
 import (
 	"context"
 
-	"github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1beta1"
+	v1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // SnapshotOps is an interface to perform k8s VolumeSnapshot operations
 type SnapshotOps interface {
 	// CreateSnapshot creates the given snapshot
-	CreateSnapshot(snap *v1beta1.VolumeSnapshot) (*v1beta1.VolumeSnapshot, error)
+	CreateSnapshot(snap *v1.VolumeSnapshot) (*v1.VolumeSnapshot, error)
 	// GetSnapshot returns the snapshot for given name and namespace
-	GetSnapshot(name string, namespace string) (*v1beta1.VolumeSnapshot, error)
+	GetSnapshot(name string, namespace string) (*v1.VolumeSnapshot, error)
 	// ListSnapshots lists all snapshots in the given namespace
-	ListSnapshots(namespace string) (*v1beta1.VolumeSnapshotList, error)
+	ListSnapshots(namespace string) (*v1.VolumeSnapshotList, error)
 	// UpdateSnapshot updates the given snapshot
-	UpdateSnapshot(snap *v1beta1.VolumeSnapshot) (*v1beta1.VolumeSnapshot, error)
+	UpdateSnapshot(snap *v1.VolumeSnapshot) (*v1.VolumeSnapshot, error)
 	// DeleteSnapshot deletes the given snapshot
 	DeleteSnapshot(name string, namespace string) error
 }
 
 // CreateSnapshot creates the given snapshot.
-func (c *Client) CreateSnapshot(snap *v1beta1.VolumeSnapshot) (*v1beta1.VolumeSnapshot, error) {
+func (c *Client) CreateSnapshot(snap *v1.VolumeSnapshot) (*v1.VolumeSnapshot, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
@@ -30,7 +30,7 @@ func (c *Client) CreateSnapshot(snap *v1beta1.VolumeSnapshot) (*v1beta1.VolumeSn
 }
 
 // GetSnapshot returns the snapshot for given name and namespace
-func (c *Client) GetSnapshot(name string, namespace string) (*v1beta1.VolumeSnapshot, error) {
+func (c *Client) GetSnapshot(name string, namespace string) (*v1.VolumeSnapshot, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func (c *Client) GetSnapshot(name string, namespace string) (*v1beta1.VolumeSnap
 }
 
 // ListSnapshots lists all snapshots in the given namespace
-func (c *Client) ListSnapshots(namespace string) (*v1beta1.VolumeSnapshotList, error) {
+func (c *Client) ListSnapshots(namespace string) (*v1.VolumeSnapshotList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func (c *Client) ListSnapshots(namespace string) (*v1beta1.VolumeSnapshotList, e
 }
 
 // UpdateSnapshot updates the given snapshot
-func (c *Client) UpdateSnapshot(snap *v1beta1.VolumeSnapshot) (*v1beta1.VolumeSnapshot, error) {
+func (c *Client) UpdateSnapshot(snap *v1.VolumeSnapshot) (*v1.VolumeSnapshot, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently Torpedo using v1beta1 api version for csi snapshot creation and this is not working with portworx CSI snapshot controller.  

Snapshot creation is failing with below error in Torpedo run:
`
19:53:05 2023-03-10 03:53:05 +0000:[INFO] [{Longevity}] [k8s.(*K8s).CreateCsiSnapshotClass:#5913] - Creating volume snapshot class: px-pure-snapshotclass03-10-03h53m05s
19:53:05 2023-03-10 03:53:05 +0000:[ERROR] [{Longevity}] [tests.TriggerCsiSnapShot.func2:#5143] - Create volume snapshot class failed with error: [Failed to create snapshot for volume: px-pure-snapshotclass03-10-03h53m05s due to err: the server could not find the requested resource (post volumesnapshotclasses.snapshot.storage.k8s.io)]
19:53:05 INFO[2023-03-10 03:53:05] Verifying : Description : verify if error occured for event csiSnapShot 
19:53:05 ERRO[2023-03-10 03:53:05] Actual:Failed to create snapshot for volume: px-pure-snapshotclass03-10-03h53m05s due to err: the server could not find the requested resource (post volumesnapshotclasses.snapshot.storage.k8s.io), Expected: <nil>
`

Updating external-snapshotter client to use v6 version so that  v1 version can be used with `VolumeSnapshotClass`. 

**Which issue(s) this PR fixes** (optional)
Closes # PTX-16420

**Special notes for your reviewer**:


