### PR TITLE
[PA-1134] DoRetryWithTimeout - return all errors on timeout

### DIFF
--- a/task/task.go
+++ b/task/task.go
@@ -30,7 +30,6 @@ func (e *ErrTimedOut) Error() string {
 // TODO(stgleb): In future I would like to add context as a first param to this function
 // so calling code can cancel task.
 func DoRetryWithTimeout(t func() (interface{}, bool, error), timeout, timeBeforeRetry time.Duration) (interface{}, error) {
-	log.Printf("DoRetryWithTimeout Timeout: (%v)", timeout)
 	// Use context.Context as a standard go way of timeout and cancellation propagation amount goroutines.
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -54,7 +53,7 @@ func DoRetryWithTimeout(t func() (interface{}, bool, error), timeout, timeBefore
 				if err != nil {
 					if retry {
 						errInRetires = append(errInRetires, err.Error())
-						log.Printf("DoRetryWithTimeout - Error: {%v}, Next try in: (%v)", err, timeBeforeRetry)
+						log.Printf("DoRetryWithTimeout - Error: {%v}, Next try in [%v], timeout [%v]", err, timeBeforeRetry, timeout)
 						time.Sleep(timeBeforeRetry)
 					} else {
 						errChan <- err


### PR DESCRIPTION
**What this PR does / why we need it**:
fix `DoRetryWithTimeout` to collect all the errors that happen in each retry and if context deadline exceeds (timeout), those errors are also returned. Returning the errors in each retry in case of timeout helps us log them to Aetos for easier access to what happened.

> even though there is a goroutine involved, there's no need for locks to the `map` since it is **never** accessed concurrently.

Closes #PA-1134