### PR TITLE
PWX-31198: record event using new eventsv1 interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ fmt:
 vet:
 	$(GO) vet ./...
 
-test:
+test: $(GOPATH)/bin/kind
 	$(GO) test ./...
 
 git-validation:
@@ -54,3 +54,7 @@ vendor:
 vendor-tidy:
 	@echo "Removing unused files in vendor tree"
 	go mod tidy
+
+$(GOPATH)/bin/kind:
+	@echo "Installing kind"
+	go install -mod=readonly sigs.k8s.io/kind@v0.16.0

--- a/k8s/core/core.go
+++ b/k8s/core/core.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -111,10 +112,20 @@ func NewInstanceFromConfigFile(config string) (Ops, error) {
 type Client struct {
 	config     *rest.Config
 	kubernetes kubernetes.Interface
-	// eventRecorders is a map of component to event recorders
-	eventRecorders     map[string]record.EventRecorder
+
+	// common lock used by both old and new recorder interfaces
 	eventRecordersLock sync.Mutex
-	eventBroadcaster   record.EventBroadcaster
+
+	// event broadcaster and recorders that record the events with the old interface
+	// (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#event-v1-core)
+	// eventRecordersLegacy is a map of component to event recorders
+	eventRecordersLegacy   map[string]record.EventRecorder
+	eventBroadcasterLegacy record.EventBroadcaster
+
+	// event broadcaster and recorders that record the events with new interface
+	// (https://pkg.go.dev/k8s.io/api/events/v1)
+	eventRecordersNew   map[string]events.EventRecorder
+	eventBroadcasterNew events.EventBroadcaster
 }
 
 // SetConfig sets the config and resets the client.

--- a/k8s/core/events.go
+++ b/k8s/core/events.go
@@ -4,11 +4,11 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -48,35 +48,76 @@ func (c *Client) ListEvents(namespace string, opts metav1.ListOptions) (*corev1.
 
 // RecorderOps is an interface to record k8s events
 type RecorderOps interface {
-	// RecordEvent records an event into k8s using client-go's EventRecorder inteface
+	// RecordEventf records a new-style event into k8s using client-go's new events.EventRecorder interface.
+	RecordEventf(
+		reportingController string, regarding runtime.Object, related runtime.Object, eventType, reason, action string,
+		note string, args ...interface{},
+	)
+
+	// RecordEvent is deprecated. Use RecordEventf instead.
+	// This function translates old-style event params to record a new-style event. Kept for backwards compatibility.
+	// New callers should use RecordEventf directly.
+	RecordEvent(source corev1.EventSource, object runtime.Object, eventtype, reason, message string)
+
+	// RecordEventLegacy records an old-style event into k8s using client-go's record.EventRecorder (deprecated) interface.
 	// It takes the event source and the object on which the event is being raised.
-	RecordEvent(source v1.EventSource, object runtime.Object, eventtype, reason, message string)
+	// Deprecated. Use RecordEventf instead.
+	RecordEventLegacy(source corev1.EventSource, object runtime.Object, eventtype, reason, message string)
 }
 
-// RecordEvent records an event into k8s using client-go's EventRecorder inteface
-func (c *Client) RecordEvent(source v1.EventSource, object runtime.Object, eventtype, reason, message string) {
+// RecordEventLegacy records an old-style event into k8s using client-go's record.EventRecorder interface.
+// Deprecated. Use RecordEventf instead.
+func (c *Client) RecordEventLegacy(source corev1.EventSource, object runtime.Object, eventtype, reason, message string) {
 	if err := c.initClient(); err != nil {
 		return
 	}
 	c.eventRecordersLock.Lock()
-	if len(c.eventRecorders) == 0 {
-		c.eventRecorders = make(map[string]record.EventRecorder)
-		c.eventBroadcaster = record.NewBroadcaster()
-		c.eventBroadcaster.StartRecordingToSink(
+	if len(c.eventRecordersLegacy) == 0 {
+		c.eventRecordersLegacy = make(map[string]record.EventRecorder)
+		c.eventBroadcasterLegacy = record.NewBroadcaster()
+		c.eventBroadcasterLegacy.StartRecordingToSink(
 			&typedcorev1.EventSinkImpl{
 				Interface: c.kubernetes.CoreV1().Events(""), // use the namespace from the object
 			},
 		)
 	}
 	key := source.Component + "-" + source.Host
-	eventRecorder, exists := c.eventRecorders[key]
+	eventRecorder, exists := c.eventRecordersLegacy[key]
 	if !exists {
-		eventRecorder = c.eventBroadcaster.NewRecorder(
+		eventRecorder = c.eventBroadcasterLegacy.NewRecorder(
 			scheme.Scheme,
 			source,
 		)
-		c.eventRecorders[key] = eventRecorder
+		c.eventRecordersLegacy[key] = eventRecorder
 	}
 	c.eventRecordersLock.Unlock()
 	eventRecorder.Event(object, eventtype, reason, message)
+}
+
+func (c *Client) RecordEvent(source corev1.EventSource, object runtime.Object, eventtype, reason, message string) {
+	c.RecordEventf(source.Component, object, nil, eventtype, reason, "Unspecified", message)
+}
+
+func (c *Client) RecordEventf(
+	reportingController string, regarding runtime.Object, related runtime.Object, eventType, reason, action string,
+	note string, args ...interface{},
+) {
+	if err := c.initClient(); err != nil {
+		return
+	}
+	c.eventRecordersLock.Lock()
+	if c.eventRecordersNew == nil {
+		c.eventRecordersNew = make(map[string]events.EventRecorder)
+		eventSink := &events.EventSinkImpl{Interface: c.kubernetes.EventsV1()}
+		c.eventBroadcasterNew = events.NewBroadcaster(eventSink)
+		stopCh := make(chan struct{}) // TODO: should we use stopCh someplace before exiting?
+		c.eventBroadcasterNew.StartRecordingToSink(stopCh)
+	}
+	eventRecorder, exists := c.eventRecordersNew[reportingController]
+	if !exists {
+		eventRecorder = c.eventBroadcasterNew.NewRecorder(scheme.Scheme, reportingController)
+		c.eventRecordersNew[reportingController] = eventRecorder
+	}
+	c.eventRecordersLock.Unlock()
+	eventRecorder.Eventf(regarding, related, eventType, reason, action, note, args...)
 }

--- a/k8s/core/events_test.go
+++ b/k8s/core/events_test.go
@@ -1,0 +1,175 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/portworx/sched-ops/k8s/testutil"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRecordEvent(t *testing.T) {
+	restCfg := testutil.SetUpTestCluster(t, "cluster1")
+
+	testClient, err := NewForConfig(restCfg)
+	require.NoError(t, err)
+
+	SetInstance(testClient)
+
+	testNamespace := "recordeventns1"
+	recreateNamespace(t, testNamespace)
+
+	testPod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod1",
+			Namespace: testNamespace,
+			UID:       "uid1",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "container1",
+					Image: "image1",
+				},
+			},
+		},
+	}
+
+	// Create a new Deployment object
+	var replicas int32 = 1
+	testDep := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dep1",
+			Namespace: testNamespace,
+			UID:       "uid2",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "app1",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "app1",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "container1",
+							Image: "image1",
+						},
+					},
+				},
+			},
+		},
+	}
+	// new interface
+	Instance().RecordEventf("controller1", testPod, testDep, "Warning", "schedulingFailed", "scheduling",
+		"%d/%d nodes not available for scheduling", 5, 5)
+
+	// backwards-compatible interface that creates new-style event
+	Instance().RecordEvent(corev1.EventSource{Component: "controller2", Host: "host2"}, testPod,
+		"Normal", "scheduled", "pod scheduled on node n1")
+
+	// backwards-compatible interface that creates an old-style event
+	Instance().RecordEventLegacy(corev1.EventSource{Component: "controller3", Host: "host3"}, testDep,
+		"Normal", "replicasReady", "all replicas are ready")
+
+	// event creation is async in client-go. Need to wait a bit.
+	var events *corev1.EventList
+	waitUntil := time.Now().Add(10 * time.Second)
+	for time.Now().Before(waitUntil) {
+		events, err = Instance().ListEvents(testNamespace, metav1.ListOptions{})
+		require.NoError(t, err)
+		if len(events.Items) == 3 {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	require.Len(t, events.Items, 3)
+	found := 0
+	for _, event := range events.Items {
+		switch event.ReportingController {
+		case "controller1":
+			require.Equal(t, event.Action, "scheduling")
+
+			require.Equal(t, "Pod", event.InvolvedObject.Kind)
+			require.Equal(t, testNamespace, event.InvolvedObject.Namespace)
+			require.Equal(t, "pod1", event.InvolvedObject.Name)
+			require.Equal(t, "uid1", string(event.InvolvedObject.UID))
+
+			require.NotNil(t, event.Related)
+			require.Equal(t, "Deployment", event.Related.Kind)
+			require.Equal(t, testNamespace, event.Related.Namespace)
+			require.Equal(t, "dep1", event.Related.Name)
+			require.Equal(t, "uid2", string(event.Related.UID))
+
+			require.Equal(t, "schedulingFailed", event.Reason)
+			require.Equal(t, "5/5 nodes not available for scheduling", event.Message)
+			require.Equal(t, "Warning", event.Type)
+			require.Equal(t, "scheduling", event.Action)
+			found++
+		case "controller2":
+			require.Equal(t, event.Action, "Unspecified")
+
+			require.Equal(t, "Pod", event.InvolvedObject.Kind)
+			require.Equal(t, testNamespace, event.InvolvedObject.Namespace)
+			require.Equal(t, "pod1", event.InvolvedObject.Name)
+			require.Equal(t, "uid1", string(event.InvolvedObject.UID))
+
+			require.Nil(t, event.Related)
+			require.Equal(t, "scheduled", event.Reason)
+			require.Equal(t, "pod scheduled on node n1", event.Message)
+			require.Equal(t, "Normal", event.Type)
+			found++
+		case "":
+			require.Equal(t, "Deployment", event.InvolvedObject.Kind)
+			require.Equal(t, testNamespace, event.InvolvedObject.Namespace)
+			require.Equal(t, "dep1", event.InvolvedObject.Name)
+			require.Equal(t, "uid2", string(event.InvolvedObject.UID))
+			require.Equal(t, "replicasReady", event.Reason)
+			require.Equal(t, "all replicas are ready", event.Message)
+			require.Equal(t, "controller3", event.Source.Component)
+			require.Equal(t, "host3", event.Source.Host)
+			require.Equal(t, 1, int(event.Count))
+			require.Equal(t, "Normal", event.Type)
+			require.Equal(t, "", event.Action)
+			found++
+		}
+	}
+	require.Equal(t, 3, found)
+}
+
+// delete and recreate the specified namespace
+func recreateNamespace(t *testing.T, name string) {
+	err := Instance().DeleteNamespace(name)
+	require.True(t, err == nil || errors.IsNotFound(err))
+	for {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+		_, err = Instance().CreateNamespace(ns)
+		if errors.IsAlreadyExists(err) {
+			t.Logf("waiting for the namespace %s to go away", name)
+			// wait for the deleted namespace to get GC'ed
+			time.Sleep(250 * time.Millisecond)
+			continue
+		}
+		break
+	}
+	require.Nil(t, err)
+}

--- a/k8s/testutil/kind.go
+++ b/k8s/testutil/kind.go
@@ -1,0 +1,153 @@
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	kindKubeConfigPath         = "/tmp/kindutil.conf"
+	ENV_PRESERVE_KIND_CLUSTERS = "PRESERVE_KIND_CLUSTERS"
+)
+
+type KindUtil interface {
+	ClusterExists(name string) (bool, error)
+	CreateCluster(name string) error
+	DestroyCluster(name string) error
+	DestroyAllClusters() error
+	GetClusterRestConfig(name string) (*rest.Config, error)
+}
+
+type kindUtil struct {
+	kindPath string
+}
+
+var once sync.Once
+var kind *kindUtil
+
+func NewKindUtil() KindUtil {
+	once.Do(func() {
+		kindPath, err := exec.LookPath("kind")
+		if err != nil {
+			logrus.Panicf("failed to locate kind: %v", err)
+		}
+		kind = &kindUtil{
+			kindPath: kindPath,
+		}
+	})
+	return kind
+}
+
+func (k *kindUtil) runCmd(cmd *exec.Cmd) (string, error) {
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to run cmd %s: %v: %w", cmd.String(), string(out), err)
+	}
+	return string(out), nil
+}
+
+func (k *kindUtil) CreateCluster(name string) error {
+	cmd := exec.Command(k.kindPath, "create", "cluster", "--name", name, "--wait=5m", "--kubeconfig", kindKubeConfigPath)
+	_, err := k.runCmd(cmd)
+	return err
+}
+
+func (k *kindUtil) DestroyCluster(name string) error {
+	cmd := exec.Command(k.kindPath, "delete", "cluster", "--name", name, "--kubeconfig", kindKubeConfigPath)
+	_, err := k.runCmd(cmd)
+	return err
+}
+
+func (k *kindUtil) DestroyAllClusters() error {
+	cmd := exec.Command(k.kindPath, "delete", "clusters", "--all", "--kubeconfig", kindKubeConfigPath)
+	_, err := k.runCmd(cmd)
+	return err
+}
+
+func (k *kindUtil) GetClusterRestConfig(name string) (*rest.Config, error) {
+	cmd := exec.Command(k.kindPath, "get", "kubeconfig", "--name", name)
+	out, err := k.runCmd(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kubeconfig from kind: %v: %w", string(out), err)
+	}
+	clientCfg, err := clientcmd.NewClientConfigFromBytes([]byte(out))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get clientCfg: %w", err)
+	}
+	restCfg, err := clientCfg.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert client config to rest config: %w", err)
+	}
+	return restCfg, nil
+}
+
+func (k *kindUtil) ClusterExists(name string) (bool, error) {
+	cmd := exec.Command(k.kindPath, "get", "clusters")
+	out, err := k.runCmd(cmd)
+	if err != nil {
+		return false, fmt.Errorf("failed to list kind clusters: %w", err)
+	}
+	clusters := strings.Split(out, "\n")
+	for _, cluster := range clusters {
+		if cluster == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func SetUpTestCluster(t *testing.T, clusterName string) *rest.Config {
+	// create a target cluster using kind if one does not exist already
+	kind := NewKindUtil()
+	exists, err := kind.ClusterExists(clusterName)
+	require.Nil(t, err)
+	if !exists {
+		t.Logf("creating kind cluster %s", clusterName)
+		err = kind.CreateCluster(clusterName)
+		require.Nil(t, err)
+		t.Cleanup(func() {
+			DestroyTestCluster(t, clusterName)
+		})
+	}
+
+	restCfg, err := kind.GetClusterRestConfig(clusterName)
+	require.Nil(t, err)
+
+	// testClient, err := client.New(restCfg, client.Options{ /*Scheme: scheme.Scheme*/ })
+	// require.Nil(t, err)
+
+	return restCfg
+}
+
+func DestroyTestCluster(t *testing.T, clusterName string) {
+	var preserveKindClusters bool = true
+	var err error
+
+	val, defined := os.LookupEnv(ENV_PRESERVE_KIND_CLUSTERS)
+	if defined {
+		preserveKindClusters, err = strconv.ParseBool(val)
+		require.Nil(t, err)
+	}
+	if preserveKindClusters {
+		t.Logf("preserving kind cluster %s; use %s=false to change", clusterName, ENV_PRESERVE_KIND_CLUSTERS)
+		return
+	}
+	kind := NewKindUtil()
+	exists, err := kind.ClusterExists(clusterName)
+	require.Nil(t, err)
+	if exists {
+		t.Logf("%s is set to %s, destroying kind cluster %s", ENV_PRESERVE_KIND_CLUSTERS, val, clusterName)
+		err = kind.DestroyCluster(clusterName)
+		require.Nil(t, err)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
client-go has a new eventsv1 interface for recording events. This patch adds a new method to record events. The old method is kept for backwards-compatibility but it creates a new-style event by mapping the original parameters to new ones. The original method that creates old-style events has been preserved by renaming it with suffix "legacy".

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**Which issue(s) this PR fixes** (optional)
PWX-31198

**Special notes for your reviewer**:

