### PR TITLE
Cherrypick ns

### DIFF
--- a/k8s/core/configmap/configmap.go
+++ b/k8s/core/configmap/configmap.go
@@ -3,7 +3,7 @@ package configmap
 import (
 	"time"
 
-	"github.com/pborman/uuid"
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -18,11 +18,11 @@ func (c *configMap) Instance() ConfigMap {
 		return c.config
 	} else {
 		existingConfig := c.config
-		c.copylock.Lock(uuid.New())
+		c.copylock.Lock(uuid.New().String())
 		defer c.copylock.Unlock()
 		lockMap, err := c.copylock.Get()
 		if err != nil {
-			log.Error("Error during fetching data from copy lock %s", err)
+			log.Errorf("Error during fetching data from copy lock %s", err)
 			return existingConfig
 		}
 		status := lockMap["UPGRADE_DONE"]

--- a/k8s/core/configmap/configmap_lock_v1.go
+++ b/k8s/core/configmap/configmap_lock_v1.go
@@ -8,11 +8,11 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-func (c *configMap) Lock(id string) error {
+func (c *coreConfigMap) Lock(id string) error {
 	return c.LockWithHoldTimeout(id, c.defaultLockHoldTimeout)
 }
 
-func (c *configMap) LockWithHoldTimeout(id string, holdTimeout time.Duration) error {
+func (c *coreConfigMap) LockWithHoldTimeout(id string, holdTimeout time.Duration) error {
 	fn := "LockWithHoldTimeout"
 	count := uint(0)
 	// try acquiring a lock on the ConfigMap
@@ -40,7 +40,7 @@ func (c *configMap) LockWithHoldTimeout(id string, holdTimeout time.Duration) er
 	return nil
 }
 
-func (c *configMap) Unlock() error {
+func (c *coreConfigMap) Unlock() error {
 	fn := "Unlock"
 	// Get the existing ConfigMap
 	c.kLockV1.Lock()
@@ -91,7 +91,7 @@ func (c *configMap) Unlock() error {
 	return err
 }
 
-func (c *configMap) tryLockV1(id string, refresh bool) (string, error) {
+func (c *coreConfigMap) tryLockV1(id string, refresh bool) (string, error) {
 	// Get the existing ConfigMap
 	cm, err := core.Instance().GetConfigMap(
 		c.name,
@@ -140,7 +140,7 @@ increase_expiry:
 	return id, nil
 }
 
-func (c *configMap) refreshLockV1(id string) {
+func (c *coreConfigMap) refreshLockV1(id string) {
 	fn := "refreshLock"
 	refresh := time.NewTicker(v1DefaultK8sLockRefreshDuration)
 	var (

--- a/k8s/core/configmap/configmap_lock_v1.go
+++ b/k8s/core/configmap/configmap_lock_v1.go
@@ -60,7 +60,7 @@ func (c *coreConfigMap) Unlock() error {
 	for retries := 0; retries < maxConflictRetries; retries++ {
 		cm, err = core.Instance().GetConfigMap(
 			c.name,
-			k8sSystemNamespace,
+			c.nameSpace,
 		)
 		if err != nil {
 			// A ConfigMap should always be created.
@@ -95,7 +95,7 @@ func (c *coreConfigMap) tryLockV1(id string, refresh bool) (string, error) {
 	// Get the existing ConfigMap
 	cm, err := core.Instance().GetConfigMap(
 		c.name,
-		k8sSystemNamespace,
+		c.nameSpace,
 	)
 	if err != nil {
 		// A ConfigMap should always be created.

--- a/k8s/core/configmap/configmap_lock_v1_test.go
+++ b/k8s/core/configmap/configmap_lock_v1_test.go
@@ -13,7 +13,7 @@ import (
 func TestLock(t *testing.T) {
 	fakeClient := fakek8sclient.NewSimpleClientset()
 	coreops.SetInstance(coreops.New(fakeClient))
-	cm, err := New("px-configmaps-test", nil, lockTimeout, 5, 0, 0)
+	cm, err := New("px-configmaps-test", nil, lockTimeout, 5, 0, 0, "test-ns")
 	require.NoError(t, err, "Unexpected error on New")
 	fmt.Println("testLock")
 
@@ -112,7 +112,7 @@ func TestLockWithHoldTimeout(t *testing.T) {
 	customHoldTimeout := defaultHoldTimeout + v1DefaultK8sLockRefreshDuration + 10*time.Second
 	fakeClient := fakek8sclient.NewSimpleClientset()
 	coreops.SetInstance(coreops.New(fakeClient))
-	cm, err := New("px-configmaps-test", nil, defaultHoldTimeout, 5, 0, 0)
+	cm, err := New("px-configmaps-test", nil, defaultHoldTimeout, 5, 0, 0, "test-ns")
 	require.NoError(t, err, "Unexpected error on New")
 	fmt.Println("TestLockWithHoldTimeout")
 

--- a/k8s/core/configmap/configmap_lock_v2.go
+++ b/k8s/core/configmap/configmap_lock_v2.go
@@ -12,7 +12,7 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-func (c *configMap) LockWithKey(owner, key string) error {
+func (c *coreConfigMap) LockWithKey(owner, key string) error {
 	if key == "" {
 		return fmt.Errorf("key cannot be empty")
 	}
@@ -54,7 +54,7 @@ func (c *configMap) LockWithKey(owner, key string) error {
 	return nil
 }
 
-func (c *configMap) UnlockWithKey(key string) error {
+func (c *coreConfigMap) UnlockWithKey(key string) error {
 	if key == "" {
 		return fmt.Errorf("key cannot be empty")
 	}
@@ -136,7 +136,7 @@ func (c *configMap) UnlockWithKey(key string) error {
 	return err
 }
 
-func (c *configMap) IsKeyLocked(key string) (bool, string, error) {
+func (c *coreConfigMap) IsKeyLocked(key string) (bool, string, error) {
 	// Get the existing ConfigMap
 	cm, err := core.Instance().GetConfigMap(
 		c.name,
@@ -170,7 +170,7 @@ func (c *configMap) IsKeyLocked(key string) (bool, string, error) {
 	return false, "", nil
 }
 
-func (c *configMap) tryLock(owner string, key string) (string, error) {
+func (c *coreConfigMap) tryLock(owner string, key string) (string, error) {
 	// Get the existing ConfigMap
 	cm, err := core.Instance().GetConfigMap(
 		c.name,
@@ -209,7 +209,7 @@ func (c *configMap) tryLock(owner string, key string) (string, error) {
 // parseLocks reads the lock data from the given ConfigMap and then converts it to:
 // * a map of keys to lock owners
 // * a map of keys to lock expiration times
-func (c *configMap) parseLocks(cm *v1.ConfigMap) (map[string]string, map[string]time.Time, error) {
+func (c *coreConfigMap) parseLocks(cm *v1.ConfigMap) (map[string]string, map[string]time.Time, error) {
 	// Check all the locks: will be an empty string if key is not present indicating no lock
 	parsedLocks := []lockData{}
 	if lock, ok := cm.Data[pxLockKey]; ok && len(lock) > 0 {
@@ -233,7 +233,7 @@ func (c *configMap) parseLocks(cm *v1.ConfigMap) (map[string]string, map[string]
 
 // checkAndTakeLock tries to take the given lock (owner, key) given the current state of the lock
 // (lockOwners, lockExpirations).
-func (c *configMap) checkAndTakeLock(
+func (c *coreConfigMap) checkAndTakeLock(
 	owner, key string,
 	lockOwners map[string]string,
 	lockExpirations map[string]time.Time,
@@ -279,7 +279,7 @@ func (c *configMap) checkAndTakeLock(
 
 // generateConfigMapData converts the given lock data (lockOwners, lockExpirations) to JSON and
 // stores it in the given ConfigMap.
-func (c *configMap) generateConfigMapData(cm *v1.ConfigMap, lockOwners map[string]string, lockExpirations map[string]time.Time) error {
+func (c *coreConfigMap) generateConfigMapData(cm *v1.ConfigMap, lockOwners map[string]string, lockExpirations map[string]time.Time) error {
 	var locks []lockData
 	for key, lockOwner := range lockOwners {
 		locks = append(locks, lockData{
@@ -297,7 +297,7 @@ func (c *configMap) generateConfigMapData(cm *v1.ConfigMap, lockOwners map[strin
 	return nil
 }
 
-func (c *configMap) updateConfigMap(cm *v1.ConfigMap) (bool, error) {
+func (c *coreConfigMap) updateConfigMap(cm *v1.ConfigMap) (bool, error) {
 	if _, err := core.Instance().UpdateConfigMap(cm); err != nil {
 		return k8s_errors.IsConflict(err), err
 	}
@@ -308,7 +308,7 @@ func (c *configMap) updateConfigMap(cm *v1.ConfigMap) (bool, error) {
 // It keeps the lock refreshed in k8s until we call Unlock. This is so that if the
 // node dies, the lock can have a short timeout and expire quickly but we can still
 // take longer-term locks.
-func (c *configMap) refreshLock(id, key string) {
+func (c *coreConfigMap) refreshLock(id, key string) {
 	fn := "refreshLock"
 	refresh := time.NewTicker(c.lockRefreshDuration)
 	var (
@@ -356,7 +356,7 @@ func (c *configMap) refreshLock(id, key string) {
 
 }
 
-func (c *configMap) checkLockTimeout(holdTimeout time.Duration, startTime time.Time, id string) {
+func (c *coreConfigMap) checkLockTimeout(holdTimeout time.Duration, startTime time.Time, id string) {
 	if holdTimeout > 0 && time.Since(startTime) > holdTimeout {
 		panicMsg := fmt.Sprintf("Lock hold timeout (%v) triggered for K8s configmap lock key %s", holdTimeout, id)
 		if fatalCb != nil {

--- a/k8s/core/configmap/configmap_lock_v2.go
+++ b/k8s/core/configmap/configmap_lock_v2.go
@@ -89,7 +89,7 @@ func (c *coreConfigMap) UnlockWithKey(key string) error {
 	for retries := 0; retries < maxConflictRetries; retries++ {
 		cm, err = core.Instance().GetConfigMap(
 			c.name,
-			k8sSystemNamespace,
+			c.nameSpace,
 		)
 		if err != nil {
 			// A ConfigMap should always be created.
@@ -140,7 +140,7 @@ func (c *coreConfigMap) IsKeyLocked(key string) (bool, string, error) {
 	// Get the existing ConfigMap
 	cm, err := core.Instance().GetConfigMap(
 		c.name,
-		k8sSystemNamespace,
+		c.nameSpace,
 	)
 	if err != nil {
 		return false, "", err
@@ -174,7 +174,7 @@ func (c *coreConfigMap) tryLock(owner string, key string) (string, error) {
 	// Get the existing ConfigMap
 	cm, err := core.Instance().GetConfigMap(
 		c.name,
-		k8sSystemNamespace,
+		c.nameSpace,
 	)
 	if err != nil {
 		// A ConfigMap should always be created.

--- a/k8s/core/configmap/configmap_lock_v2_test.go
+++ b/k8s/core/configmap/configmap_lock_v2_test.go
@@ -17,7 +17,7 @@ const (
 func TestMultilock(t *testing.T) {
 	fakeClient := fakek8sclient.NewSimpleClientset()
 	coreops.SetInstance(coreops.New(fakeClient))
-	cm, err := New("px-configmaps-test", nil, lockTimeout, 3, 0, 0)
+	cm, err := New("px-configmaps-test", nil, lockTimeout, 3, 0, 0, "test-ns")
 	require.NoError(t, err, "Unexpected error on New")
 
 	fmt.Println("testMultilock")

--- a/k8s/core/configmap/configmap_test.go
+++ b/k8s/core/configmap/configmap_test.go
@@ -1,0 +1,90 @@
+package configmap
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	coreops "github.com/portworx/sched-ops/k8s/core"
+	fakek8sclient "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetConfigMap(t *testing.T) {
+	fakeClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(fakeClient))
+
+	configData := map[string]string{
+		"key1": "val1",
+	}
+	cm, err := New("px-configmaps-test", configData, lockTimeout, 5, 0, 0, "test-ns")
+	fmt.Println("cm : ", cm)
+	require.NoError(t, err, "Unexpected error in creating configmap")
+
+	resultMap, err := cm.Get()
+	require.NoError(t, err, "Unexpected error in getting configmap")
+	require.Contains(t, resultMap, "key1")
+	fmt.Println(resultMap)
+}
+
+func TestDeleteConfigMap(t *testing.T) {
+	fakeClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(fakeClient))
+
+	configData := map[string]string{
+		"key1": "val1",
+	}
+
+	cm, err := New("px-configmaps-test", configData, lockTimeout, 5, 0, 0, "test-ns")
+	require.NoError(t, err, "Unexpected error in creating configmap")
+
+	err = cm.Delete()
+	require.NoError(t, err, "Unexpected error in delete")
+
+}
+
+func TestPatchConfigMap(t *testing.T) {
+	fakeClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(fakeClient))
+
+	configData := map[string]string{
+		"key1": "val1",
+	}
+
+	cm, err := New("px-configmaps-test", configData, lockTimeout, 5, 0, 0, "test-ns")
+	require.NoError(t, err, "Unexpected error in creating configmap")
+
+	dummyData := map[string]string{
+		"key2": "val2",
+	}
+
+	err = cm.Patch(dummyData)
+	require.NoError(t, err, "Unexpected error in Patch")
+	resultMap, err := cm.Get()
+	require.Contains(t, resultMap, "key1")
+	require.Contains(t, resultMap, "key2")
+	fmt.Println(resultMap)
+}
+
+func TestUpdateConfigMap(t *testing.T) {
+	fakeClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(fakeClient))
+
+	configData := map[string]string{
+		"key1": "val1",
+	}
+
+	cm, err := New("px-configmaps-test", configData, lockTimeout, 5, 0, 0, "test-ns")
+	require.NoError(t, err, "Unexpected error in creating configmap")
+
+	dummyData := map[string]string{
+		"key2": "val2",
+	}
+
+	err = cm.Update(dummyData)
+	require.NoError(t, err, "Unexpected error in Update")
+	resultMap, err := cm.Get()
+	require.NotContains(t, resultMap, "key1")
+	require.Contains(t, resultMap, "key2")
+	fmt.Println(resultMap)
+}

--- a/k8s/core/configmap/coreconfigmap.go
+++ b/k8s/core/configmap/coreconfigmap.go
@@ -73,7 +73,7 @@ func New(
 			Namespace: pxNamespace,
 		},
 		Data: map[string]string{
-			upgradeCompletedStatus: true,
+			upgradeCompletedStatus: trueString,
 		},
 	}
 
@@ -84,13 +84,13 @@ func New(
 		fmt.Println("Failed to create configmap-copylock")
 		return nil, fmt.Errorf("failed to create configmap %v: %v",
 			name, err)
-	} else {
-		copyLock.name = pxCopyLockConfigMap
-		copyLock.kLocksV2 = map[string]*k8sLock{}
-		copyLock.lockRefreshDuration = v2LockRefreshDuration
-		copyLock.lockK8sLockTTL = v2LockK8sLockTTL
-		copyLock.nameSpace = pxNamespace
 	}
+
+	copyLock.name = pxCopyLockConfigMap
+	copyLock.kLocksV2 = map[string]*k8sLock{}
+	copyLock.lockRefreshDuration = v2LockRefreshDuration
+	copyLock.lockK8sLockTTL = v2LockK8sLockTTL
+	copyLock.nameSpace = pxNamespace
 
 	return &configMap{
 		config:   config,

--- a/k8s/core/configmap/coreconfigmap.go
+++ b/k8s/core/configmap/coreconfigmap.go
@@ -1,0 +1,192 @@
+package configmap
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/portworx/sched-ops/k8s/core"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// New returns the ConfigMap interface. It also creates a new
+// configmap in k8s for the given name if not present and puts the data in it.
+func New(
+	name string,
+	data map[string]string,
+	lockTimeout time.Duration,
+	lockAttempts uint,
+	v2LockRefreshDuration time.Duration,
+	v2LockK8sLockTTL time.Duration,
+	ns string,
+) (ConfigMap, error) {
+	if data == nil {
+		data = make(map[string]string)
+	}
+
+	//if copylock not created, then create
+
+	labels := map[string]string{
+		configMapUserLabelKey: TruncateLabel(name),
+	}
+	data[pxOwnerKey] = ""
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    labels,
+		},
+		Data: data,
+	}
+
+	if _, err := core.Instance().CreateConfigMap(cm); err != nil &&
+		!k8s_errors.IsAlreadyExists(err) {
+		return nil, fmt.Errorf("failed to create configmap %v: %v",
+			name, err)
+	}
+
+	if v2LockK8sLockTTL == 0 {
+		v2LockK8sLockTTL = v2DefaultK8sLockTTL
+	}
+
+	if v2LockRefreshDuration == 0 {
+		v2LockRefreshDuration = v2DefaultK8sLockRefreshDuration
+	}
+
+	return &coreConfigMap{
+		name:                   name,
+		defaultLockHoldTimeout: lockTimeout,
+		kLocksV2:               map[string]*k8sLock{},
+		lockAttempts:           lockAttempts,
+		lockRefreshDuration:    v2LockRefreshDuration,
+		lockK8sLockTTL:         v2LockK8sLockTTL,
+		nameSpace:              ns,
+	}, nil
+}
+
+func (c *coreConfigMap) Get() (map[string]string, error) {
+	cm, err := core.Instance().GetConfigMap(
+		c.name,
+		c.nameSpace,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return cm.Data, nil
+}
+
+func (c *coreConfigMap) Delete() error {
+	return core.Instance().DeleteConfigMap(
+		c.name,
+		c.nameSpace,
+	)
+}
+
+func (c *coreConfigMap) Patch(data map[string]string) error {
+	var (
+		err error
+		cm  *corev1.ConfigMap
+	)
+	for retries := 0; retries < maxConflictRetries; retries++ {
+		cm, err = core.Instance().GetConfigMap(
+			c.name,
+			c.nameSpace,
+		)
+		if err != nil {
+			return err
+		}
+
+		if cm.Data == nil {
+			cm.Data = make(map[string]string, 0)
+		}
+
+		for k, v := range data {
+			cm.Data[k] = v
+		}
+		_, err = core.Instance().UpdateConfigMap(cm)
+		if k8s_errors.IsConflict(err) {
+			// try again
+			continue
+		}
+		return err
+	}
+	return err
+}
+
+func (c *coreConfigMap) Update(data map[string]string) error {
+	var (
+		err error
+		cm  *corev1.ConfigMap
+	)
+	for retries := 0; retries < maxConflictRetries; retries++ {
+		cm, err = core.Instance().GetConfigMap(
+			c.name,
+			c.nameSpace,
+		)
+		if err != nil {
+			return err
+		}
+		cm.Data = data
+		_, err = core.Instance().UpdateConfigMap(cm)
+		if k8s_errors.IsConflict(err) {
+			// try again
+			continue
+		}
+		return err
+	}
+	return err
+}
+
+// SetFatalCb sets the fatal callback for the package which will get invoked in panic situations
+func SetFatalCb(fb FatalCb) {
+	fatalCb = fb
+}
+
+func configMapLog(fn, name, owner, key string, err error) *logrus.Entry {
+	if len(owner) > 0 && len(key) > 0 {
+		return logrus.WithFields(logrus.Fields{
+			"Module":   "ConfigMap",
+			"Name":     name,
+			"Owner":    owner,
+			"Key":      key,
+			"Function": fn,
+			"Error":    err,
+		})
+	}
+	if len(owner) > 0 {
+		return logrus.WithFields(logrus.Fields{
+			"Module":   "ConfigMap",
+			"Name":     name,
+			"Owner":    owner,
+			"Function": fn,
+			"Error":    err,
+		})
+	}
+	return logrus.WithFields(logrus.Fields{
+		"Module":   "ConfigMap",
+		"Name":     name,
+		"Function": fn,
+		"Error":    err,
+	})
+}
+
+// GetName is a helper function that returns a valid k8s
+// configmap name given a prefix identifying the component using
+// the configmap and a clusterID
+func GetName(prefix, clusterID string) string {
+	return prefix + strings.ToLower(configMapNameRegex.ReplaceAllString(clusterID, ""))
+}
+
+// TruncateLabel is a helper function that returns a valid k8s
+// label stripped down to 63 characters. It removes the trailing characters
+func TruncateLabel(label string) string {
+	if len(label) > 63 {
+		return label[:63]
+	}
+	return label
+}

--- a/k8s/core/configmap/coreconfigmap.go
+++ b/k8s/core/configmap/coreconfigmap.go
@@ -57,7 +57,7 @@ func New(
 		v2LockRefreshDuration = v2DefaultK8sLockRefreshDuration
 	}
 
-	return &coreConfigMap{
+	config := &coreConfigMap{
 		name:                   name,
 		defaultLockHoldTimeout: lockTimeout,
 		kLocksV2:               map[string]*k8sLock{},
@@ -65,6 +65,11 @@ func New(
 		lockRefreshDuration:    v2LockRefreshDuration,
 		lockK8sLockTTL:         v2LockK8sLockTTL,
 		nameSpace:              ns,
+	}
+	return &configMap{
+		config:   config,
+		pxNs:     ns,
+		copylock: nil,
 	}, nil
 }
 

--- a/k8s/core/configmap/types.go
+++ b/k8s/core/configmap/types.go
@@ -45,8 +45,8 @@ const (
 	configMapUserLabelKey  = "user"
 	maxConflictRetries     = 3
 	upgradeCompletedStatus = "UPGRADE_DONE"
-	true                   = "true"
-	false                  = "false"
+	trueString             = "true"
+	falseString            = "false"
 	pxNamespace            = "portworx"
 	pxCopyLockConfigMap    = "configmaps-copylock"
 )

--- a/k8s/core/configmap/types.go
+++ b/k8s/core/configmap/types.go
@@ -41,9 +41,14 @@ const (
 	// objects.
 	pxLockKey = "px-lock"
 
-	lockSleepDuration     = 1 * time.Second
-	configMapUserLabelKey = "user"
-	maxConflictRetries    = 3
+	lockSleepDuration      = 1 * time.Second
+	configMapUserLabelKey  = "user"
+	maxConflictRetries     = 3
+	upgradeCompletedStatus = "UPGRADE_DONE"
+	true                   = "true"
+	false                  = "false"
+	pxNamespace            = "portworx"
+	pxCopyLockConfigMap    = "configmaps-copylock"
 )
 
 var (

--- a/k8s/core/configmap/types.go
+++ b/k8s/core/configmap/types.go
@@ -58,7 +58,14 @@ var (
 type FatalCb func(format string, args ...interface{})
 
 type configMap struct {
+	config   *coreConfigMap
+	pxNs     string
+	copylock *coreConfigMap
+}
+
+type coreConfigMap struct {
 	name                   string
+	nameSpace              string
 	kLockV1                k8sLock
 	kLocksV2Mutex          sync.Mutex
 	kLocksV2               map[string]*k8sLock

--- a/k8s/core/configmaps.go
+++ b/k8s/core/configmaps.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -28,7 +27,6 @@ type ConfigMapOps interface {
 
 // GetConfigMap gets the config map object for the given name and namespace
 func (c *Client) GetConfigMap(name string, namespace string) (*corev1.ConfigMap, error) {
-	fmt.Println("Searching for configmap ", name, " in ns ", namespace)
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}

--- a/k8s/core/configmaps.go
+++ b/k8s/core/configmaps.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +28,7 @@ type ConfigMapOps interface {
 
 // GetConfigMap gets the config map object for the given name and namespace
 func (c *Client) GetConfigMap(name string, namespace string) (*corev1.ConfigMap, error) {
+	fmt.Println("Searching for configmap ", name, " in ns ", namespace)
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
https://portworx.atlassian.net/browse/PWX-30230

This PR is for migration of namespace from 'kube-system' to 'portworx'. To support this,

Added coreConfigMap struct as wrapper function for existing configmap.
Added Instance() to decide which configmap to use, and handle upgrade scenarios
Logic to update copylock config map entry once upgrade is finished will be handled in porx code.
This PR is to cherrypick changes to 'porx' branch of sched-ops, to update vendor dependency in porx repo.