### PR TITLE
PWX-32122: Added PortworxDiags to the Ops interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc7
 	github.com/libopenstorage/autopilot-api v1.3.0
 	github.com/libopenstorage/openstorage v9.4.47+incompatible
-	github.com/libopenstorage/operator v0.0.0-20230323034810-8853b151f594
+	github.com/libopenstorage/operator v0.0.0-20230801044606-e27dec4914d4
 	github.com/libopenstorage/stork v1.4.1-0.20230330233319-e17ea1b3fd81
-	github.com/openshift/api v0.0.0-20210105115604-44119421ec6b
+	github.com/openshift/api v0.0.0-20230426193520-54a14470e5dc
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
 	// TODO: Vendor from pb-1874 branch. Need to change it to master.
 	github.com/portworx/kdmp v0.4.1-0.20230316085313-95fc97e8493b

--- a/go.sum
+++ b/go.sum
@@ -1767,6 +1767,8 @@ github.com/libopenstorage/operator v0.0.0-20221128182303-7bedcffb60e6/go.mod h1:
 github.com/libopenstorage/operator v0.0.0-20230202214252-140e2e1fd86a/go.mod h1:Q66wsNUAekPawgGg9yh0Bs7eXWPa4/+c2JTefdiDciM=
 github.com/libopenstorage/operator v0.0.0-20230323034810-8853b151f594 h1:pVtnM9o5BlvWSrRphA7qJsV32bXW98cmxhHlA2xrA9E=
 github.com/libopenstorage/operator v0.0.0-20230323034810-8853b151f594/go.mod h1:0S4k1ouTScuVS3rxPukfEFvc5bMasmI1wpAAM0NejWQ=
+github.com/libopenstorage/operator v0.0.0-20230801044606-e27dec4914d4 h1:TT2Q2QUoP+yPal2mHSOsjkFMq8BGE+TgySHOXqbij1E=
+github.com/libopenstorage/operator v0.0.0-20230801044606-e27dec4914d4/go.mod h1:Lc0sagIlgkrXHn+vwR9JfZkAkSsdedtbrRx42qF0vMc=
 github.com/libopenstorage/secrets v0.0.0-20210908194121-a1d19aa9713a/go.mod h1:gE8rSd6lwLNXNbiW3DrRZjFMs+y4fDHy/6uiOO9cdzY=
 github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9/go.mod h1:gE8rSd6lwLNXNbiW3DrRZjFMs+y4fDHy/6uiOO9cdzY=
 github.com/libopenstorage/stork v1.4.1-0.20230330233319-e17ea1b3fd81 h1:JV58xSaMIZdYeGalZHL1g/DtwD9D0rcnsEDWlbYmeWE=
@@ -2063,6 +2065,8 @@ github.com/opencontainers/selinux v1.10.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuh
 github.com/openshift/api v0.0.0-20190322043348-8741ff068a47/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/api v0.0.0-20210105115604-44119421ec6b h1:9wG43AJGupRUUAAF/GN2CtQgVlo+BzdIlmsTwUlIATE=
 github.com/openshift/api v0.0.0-20210105115604-44119421ec6b/go.mod h1:aqU5Cq+kqKKPbDMqxo9FojgDeSpNJI7iuskjXjtojDg=
+github.com/openshift/api v0.0.0-20230426193520-54a14470e5dc h1:U/ran9ckjGV/aSVTrWHFa/DY2L4Y1PT5N0lSDe/4of4=
+github.com/openshift/api v0.0.0-20230426193520-54a14470e5dc/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20180830153425-431ec9a26e50/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47 h1:+TEY29DK0XhqB7HFC9OfV8qf3wffSyi7MWv3AP28DGQ=

--- a/k8s/operator/operator.go
+++ b/k8s/operator/operator.go
@@ -23,6 +23,7 @@ var (
 type Ops interface {
 	StorageClusterOps
 	StorageNodeOps
+	PortworxDiagOps
 
 	// SetConfig sets the config and resets the client
 	SetConfig(config *rest.Config)

--- a/k8s/operator/portworxdiag.go
+++ b/k8s/operator/portworxdiag.go
@@ -1,0 +1,80 @@
+package operator
+
+import (
+	"context"
+
+	portworxv1 "github.com/libopenstorage/operator/pkg/apis/portworx/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PortworxDiagOps is an interface to perfrom k8s PortworxDiag operations
+type PortworxDiagOps interface {
+	// CreatePortworxDiag creates the given PortworxDiag
+	CreatePortworxDiag(*portworxv1.PortworxDiag) (*portworxv1.PortworxDiag, error)
+	// UpdatePortworxDiag updates the given PortworxDiag
+	UpdatePortworxDiag(*portworxv1.PortworxDiag) (*portworxv1.PortworxDiag, error)
+	// GetPortworxDiag gets the PortworxDiag with given name and namespace
+	GetPortworxDiag(string, string) (*portworxv1.PortworxDiag, error)
+	// ListPortworxDiags lists all the PortworxDiags
+	ListPortworxDiags(string) (*portworxv1.PortworxDiagList, error)
+	// DeletePortworxDiag deletes the given PortworxDiag
+	DeletePortworxDiag(string, string) error
+	// UpdatePortworxDiagStatus update the status of given PortworxDiag
+	UpdatePortworxDiagStatus(*portworxv1.PortworxDiag) (*portworxv1.PortworxDiag, error)
+}
+
+// CreatePortworxDiag creates the given PortworxDiag
+func (c *Client) CreatePortworxDiag(diag *portworxv1.PortworxDiag) (*portworxv1.PortworxDiag, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	ns := diag.Namespace
+	if len(ns) == 0 {
+		ns = metav1.NamespaceDefault
+	}
+
+	return c.ost.PortworxV1().PortworxDiags(ns).Create(context.TODO(), diag, metav1.CreateOptions{})
+}
+
+// UpdatePortworxDiag updates the given PortworxDiag
+func (c *Client) UpdatePortworxDiag(diag *portworxv1.PortworxDiag) (*portworxv1.PortworxDiag, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.ost.PortworxV1().PortworxDiags(diag.Namespace).Update(context.TODO(), diag, metav1.UpdateOptions{})
+}
+
+// GetPortworxDiag gets the PortworxDiag with given name and namespace
+func (c *Client) GetPortworxDiag(name, namespace string) (*portworxv1.PortworxDiag, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.ost.PortworxV1().PortworxDiags(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+// ListPortworxDiags lists all the PortworxDiags
+func (c *Client) ListPortworxDiags(namespace string) (*portworxv1.PortworxDiagList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.ost.PortworxV1().PortworxDiags(namespace).List(context.TODO(), metav1.ListOptions{})
+}
+
+// DeletePortworxDiag deletes the given PortworxDiag
+func (c *Client) DeletePortworxDiag(name, namespace string) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+
+	return c.ost.PortworxV1().PortworxDiags(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+}
+
+// UpdatePortworxDiagStatus update the status of given PortworxDiag
+func (c *Client) UpdatePortworxDiagStatus(diag *portworxv1.PortworxDiag) (*portworxv1.PortworxDiag, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.ost.PortworxV1().PortworxDiags(diag.Namespace).UpdateStatus(context.TODO(), diag, metav1.UpdateOptions{})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
To integration test the new PortworxDiag CR, we need to be able to access them in Kubernetes from the tests. This is usually done through the Ops interface, so we should add the new CR there.

