### PR TITLE
PWX-32793 : add support for raw block devices

### DIFF
--- a/k8s/core/pods.go
+++ b/k8s/core/pods.go
@@ -242,6 +242,13 @@ func (c *Client) getPodsUsingPVCWithListOptions(pvcName, pvcNamespace string, op
 							break containerLoop
 						}
 					}
+					// adding check for rawblock volume devices
+					for _, device := range container.VolumeDevices {
+						if device.Name == v.Name {
+							retList = append(retList, p)
+							break containerLoop
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Add support for raw block devices
**Which issue(s) this PR fixes** (optional)
Closes #PWX-32793

**Special notes for your reviewer**:
- In listing pods using pvc we were checking volume mounts to list the pods
- In case of raw block volumes, we need to check volume devices instead of volume mounts, hence we need to update this method for listing pods using pvc's
