### PR TITLE
Updated configMapLockv1 with tests

### DIFF
--- a/k8s/core/configmap/configmap.go
+++ b/k8s/core/configmap/configmap.go
@@ -61,6 +61,7 @@ func New(
 		lockAttempts:           lockAttempts,
 		lockRefreshDuration:    v2LockRefreshDuration,
 		lockK8sLockTTL:         v2LockK8sLockTTL,
+		kLockV1:                k8sLock{done: make(chan struct{}), id: ""}, // Initialize kLockV1 here
 	}, nil
 }
 

--- a/k8s/core/configmap/configmap_lock_v1_test.go
+++ b/k8s/core/configmap/configmap_lock_v1_test.go
@@ -88,16 +88,16 @@ func TestLock(t *testing.T) {
 	fatalLockCb := func(format string, args ...interface{}) {
 		fmt.Println("\tLock timeout called.")
 		lockTimedout = true
-		err := cm.Unlock()
-		require.NoError(t, err, "Unexpected error from Unlock")
 	}
 	SetFatalCb(fatalLockCb)
 
-	// Check lock expiration
 	err = cm.Lock("id2")
 	require.NoError(t, err, "Unexpected error in lock")
 	time.Sleep(20 * time.Second)
 	require.True(t, lockTimedout, "Lock hold timeout not triggered")
+
+	err = cm.Unlock()
+	require.NoError(t, err, "Unexpected no error in unlock")
 
 	err = cm.Lock("id3")
 	require.NoError(t, err, "Lock should have expired")
@@ -120,14 +120,16 @@ func TestLockWithHoldTimeout(t *testing.T) {
 	fatalLockCb := func(format string, args ...interface{}) {
 		fmt.Println("\tLock timeout called.")
 		lockTimedout = true
-		err := cm.Unlock()
-		require.NoError(t, err, "Unexpected error from Unlock")
 	}
 	SetFatalCb(fatalLockCb)
 
 	// when custom lock hold timeout is more than the default lock hold timeout
 	err = cm.LockWithHoldTimeout("id1", customHoldTimeout)
 	require.NoError(t, err, "Unexpected error in lock")
+	time.Sleep(20 * time.Second)
+
+	err = cm.Unlock()
+	require.NoError(t, err, "Unexpected no error in unlock")
 
 	// lock hold timeout should not trigger after the default lock hold timeout period (plus refresh interval)
 	time.Sleep(customHoldTimeout - 8*time.Second)


### PR DESCRIPTION
Updated configMapLockv1 with tests

PWX-33673

Testing Done :-

```
rkinhalkar@dev-rkinhalkar:/home/rkinhalkar/go/src/github.com/portworx/sched-ops/k8s/core/configmap$ go test -v
=== RUN   TestLock
testLock
	lock
	unlock
	relock
	reunlock
	repeat lock once
	repeat lock lock twice
	repeat lock unlock once
	trepeat lock unlock twice
	lockExpiration
	Lock timeout called.
--- PASS: TestLock (28.01s)
=== RUN   TestLockWithHoldTimeout
TestLockWithHoldTimeout
--- PASS: TestLockWithHoldTimeout (33.00s)
```

