### PR TITLE
PB-4601: Upon restoring kubevirt VM, there is a change in VM spec par…

### DIFF
--- a/k8s/kubevirt/virtualmachine.go
+++ b/k8s/kubevirt/virtualmachine.go
@@ -76,8 +76,9 @@ func (c *Client) ValidateVirtualMachineRunning(name, namespace string, timeout, 
 	}
 
 	// Start the VirtualMachine if its not Started yet
-	if !*vm.Spec.Running {
-		if err = instance.StartVirtualMachine(vm); err != nil {
+	if vm.Status.PrintableStatus == kubevirtv1.VirtualMachineStatusStopped ||
+		vm.Status.PrintableStatus == kubevirtv1.VirtualMachineStatusStopping {
+		if err = c.StartVirtualMachine(vm); err != nil {
 			return fmt.Errorf("Failed to start VirtualMachine %v", err)
 		}
 	}


### PR DESCRIPTION
…ameter

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Fixes PB-4601. Not all VMs have spec.Running. Stork removes Spec.Running element and replaces it with runStrategy. This causes validateVirtualMachineRunningState fails. This PR fixes this to handle it gracefully. 
**Which issue(s) this PR fixes** (optional)
Closes #
PB-4601
**Special notes for your reviewer**:
None
