### PR TITLE
Added a method to get kubevirt control plane version

### DIFF
--- a/k8s/kubevirt/kubevirt.go
+++ b/k8s/kubevirt/kubevirt.go
@@ -22,6 +22,9 @@ type Ops interface {
 
 	// SetConfig sets the config and resets the client
 	SetConfig(config *rest.Config)
+
+	// GetVersion gets the version of kubevirt control plane
+	GetVersion() (string, error)
 }
 
 // Instance returns a singleton instance of the client.
@@ -79,6 +82,19 @@ type Client struct {
 func (c *Client) SetConfig(cfg *rest.Config) {
 	c.config = cfg
 	c.kubevirt = nil
+}
+
+// GetVersion gets the version of kubevirt control plane
+func (c *Client) GetVersion() (string, error) {
+	if err := c.initClient(); err != nil {
+		return "", err
+	}
+	versionInfo, err := c.kubevirt.ServerVersion().Get()
+	if err != nil {
+		return "", err
+	}
+	version := versionInfo.String()
+	return version, nil
 }
 
 // initClient the k8s client if uninitialized


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to to check the version of kubevirt control plane before upgrading

**Which issue(s) this PR fixes** (optional)
Closes #PB-4830

**Special notes for your reviewer**:

