### PR TITLE
PB-4403: alert manager config for email alert

### DIFF
--- a/k8s/prometheus/alertmanagerconfig.go
+++ b/k8s/prometheus/alertmanagerconfig.go
@@ -1,0 +1,71 @@
+package prometheus
+
+import (
+	"context"
+
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// * AlertManagerConfig adds receiver to alert manager which is responsible sending alerts
+type AlertManagerConfigOps interface {
+	// * List of alertmanagerconfigs that match the namespace
+	ListAlertManagerConfigs(namespace string) (*monitoringv1alpha1.AlertmanagerConfigList, error)
+	// * Get alertmanagerconfigs that matches the name
+	GetAlertManagerConfig(name string, namespace string) (*monitoringv1alpha1.AlertmanagerConfig, error)
+	// * Create a new alertmanagerconfig
+	CreateAlertManagerConfig(*monitoringv1alpha1.AlertmanagerConfig) (*monitoringv1alpha1.AlertmanagerConfig, error)
+	// * Update one alertmanagerconfig
+	UpdateAlertManagerConfig(*monitoringv1alpha1.AlertmanagerConfig) (*monitoringv1alpha1.AlertmanagerConfig, error)
+	// * Delete one alertmanagerconfig
+	DeleteAlertManagerConfig(name string, namespace string) error
+}
+
+// * List of alert manager configs that match the namespace
+func (c *Client) ListAlertManagerConfigs(namespace string) (*monitoringv1alpha1.AlertmanagerConfigList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(namespace).List(context.TODO(), metav1.ListOptions{})
+}
+
+// * Get one alert manager config
+func (c *Client) GetAlertManagerConfig(name string, namespace string) (*monitoringv1alpha1.AlertmanagerConfig, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+// * Creates a new AlertmanagerConfig in the given namespace, provided the secret is provided
+func (c *Client) CreateAlertManagerConfig(amc *monitoringv1alpha1.AlertmanagerConfig) (*monitoringv1alpha1.AlertmanagerConfig, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	ns := amc.Namespace
+	if len(ns) == 0 {
+		ns = corev1.NamespaceDefault
+	}
+	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(ns).Create(context.TODO(), amc, metav1.CreateOptions{})
+}
+
+// * Updates one alert manager config
+func (c *Client) UpdateAlertManagerConfig(amc *monitoringv1alpha1.AlertmanagerConfig) (*monitoringv1alpha1.AlertmanagerConfig, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(amc.Namespace).Update(context.TODO(), amc, metav1.UpdateOptions{})
+}
+
+// * Deletes single alert manager config
+func (c *Client) DeleteAlertManagerConfig(name string, namespace string) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+
+	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{
+		PropagationPolicy: &deleteForegroundPolicy,
+	})
+}

--- a/k8s/prometheus/prometheus.go
+++ b/k8s/prometheus/prometheus.go
@@ -25,6 +25,7 @@ type Ops interface {
 	PodOps
 	RuleOps
 	AlertManagerOps
+	AlertManagerConfigOps
 
 	// SetConfig sets the config and resets the client
 	SetConfig(config *rest.Config)


### PR DESCRIPTION
**What this PR does / why we need it**:
- Email alert requires alertmanagerconfig to create receivers list, which then gets picked up by alert manager to send emails based on respective logs.

- This is the api px-backup uses to manage the amc
**Which issue(s) this PR fixes** (optional)

Closes #
This is based on the ticket of [pb-4403](https://portworx.atlassian.net/browse/PB-4403)
