### PR TITLE
Created VirtualMachineInstanceOps interface

### DIFF
--- a/k8s/kubevirt/kubevirt.go
+++ b/k8s/kubevirt/kubevirt.go
@@ -19,6 +19,7 @@ var (
 // Ops is an interface to perform kubernetes related operations on the core resources.
 type Ops interface {
 	VirtualMachineOps
+	VirtualMachineInstanceOps
 
 	// SetConfig sets the config and resets the client
 	SetConfig(config *rest.Config)

--- a/k8s/kubevirt/virtualmachineinstance.go
+++ b/k8s/kubevirt/virtualmachineinstance.go
@@ -1,0 +1,22 @@
+package kubevirt
+
+import (
+	"context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+// VirtualMachineInstanceOps is an interface to perform kubevirt operations on virtual machine instances
+type VirtualMachineInstanceOps interface {
+	// GetVirtualMachineInstance gets updated Virtual Machine Instance from client matching name and namespace
+	GetVirtualMachineInstance(context.Context, string, string) (*kubevirtv1.VirtualMachineInstance, error)
+}
+
+// GetVirtualMachineInstance gets updated Virtual Machine Instance from client matching name and namespace
+func (c *Client) GetVirtualMachineInstance(ctx context.Context, name string, namespace string) (*kubevirtv1.VirtualMachineInstance, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.kubevirt.VirtualMachineInstance(namespace).Get(ctx, name, &metav1.GetOptions{})
+}


### PR DESCRIPTION
What this PR does / why we need it:
Created VirtualMachineInstanceOps interface. Needed this in torpedo to get the Virtual Machine IP Address which is part of the VMI spec.

Which issue(s) this PR fixes (optional)
Closes #PB-4793

Special notes for your reviewer: Tested this in torpedo - https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/4376/