### PR TITLE
add method to get the kubevirt typed client

### DIFF
--- a/k8s/kubevirt/kubevirt.go
+++ b/k8s/kubevirt/kubevirt.go
@@ -18,6 +18,7 @@ var (
 
 // Ops is an interface to perform kubernetes related operations on the core resources.
 type Ops interface {
+	GetKubevirtClient() kubecli.KubevirtClient
 	VirtualMachineOps
 	VirtualMachineInstanceOps
 
@@ -163,4 +164,11 @@ func (c *Client) loadClient() error {
 	}
 
 	return nil
+}
+
+func (c *Client) GetKubevirtClient() kubecli.KubevirtClient {
+	if err := c.initClient(); err != nil {
+		return nil
+	}
+	return c.kubevirt
 }


### PR DESCRIPTION


<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Enables the use the KubeVirt client directly without having add methods in sched-ops for each object.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

