### PR TITLE
PWX-36344: Fixes deadlock in configmap lock v1

### DIFF
--- a/k8s/core/configmap/configmap.go
+++ b/k8s/core/configmap/configmap.go
@@ -61,7 +61,7 @@ func New(
 		lockAttempts:           lockAttempts,
 		lockRefreshDuration:    v2LockRefreshDuration,
 		lockK8sLockTTL:         v2LockK8sLockTTL,
-		kLockV1:                k8sLock{done: make(chan struct{}), id: ""}, // Initialize kLockV1 here
+		kLockV1:                k8sLock{done: make(chan struct{}, 1), id: ""}, // Initialize kLockV1 here
 	}, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a very small chance of deadlock in the configmap lock v1 implementation. It requires this exact order of calls:
1. We call `Unlock()` which takes `kLockV1.Lock()` [here](https://github.com/portworx/sched-ops/blob/master/k8s/core/configmap/configmap_lock_v1.go#L48)
2. `refreshLockV1` enters the `<-refresh.C` select case [here](https://github.com/portworx/sched-ops/blob/master/k8s/core/configmap/configmap_lock_v1.go#L155), and also tries to take `kLockV1.Lock()`. It now hangs.
3. `Unlock()` now tries to write to `kLockV1.done` [here](https://github.com/portworx/sched-ops/blob/master/k8s/core/configmap/configmap_lock_v1.go#L56), an unbuffered channel. As `refreshLockV1` is stuck in the select case, it is not able to read the value from the channel, and thus `Unlock()` never releases the lock. As @adityadani put it, "classic deadlock".

The solution here is to make the channel `kLockV1.done` into a buffered channel (of size 1), so that in this case the channel write would complete, allowing `Unlock()` to finish and thus allowing `refreshLockV1` to finish.

**Which issue(s) this PR fixes** (optional)
PWX-36344

**Testing notes**:
This was not detected by `go test -race`: across 5 runs, the average number of race conditions detected was the same for both the buffered and unbuffered channel version.

While a continuous automated test is not possible due to the extreme timing of this incident, I was able to make a manual test that reproduced this incident:
```golang
func TestLockInducedDeadlock(t *testing.T) {
	fakeClient := fakek8sclient.NewSimpleClientset()
	coreops.SetInstance(coreops.New(fakeClient))
	cm, err := New("px-configmaps-test", nil, lockTimeout, 5, 0, 0)
	require.NoError(t, err, "Unexpected error on New")
	fmt.Println("testLock")

	id := "locktest"
	err = cm.Lock(id)
	require.NoError(t, err, "Unexpected error in lock")

	err = cm.Unlock()
	require.NoError(t, err, "Unexpected error in unlock")
}
```

With an unbuffered channel, the test times out with this error:
```
go test -timeout 30s -run ^TestLockInducedDeadlock$

testLock
time="2024-03-08T23:13:31Z" level=info msg="Unlock doing debug sleep"
time="2024-03-08T23:13:39Z" level=info msg="refreshLockV1 entered select refresh.C block"
time="2024-03-08T23:13:47Z" level=info msg="Continuing with unlock, hitting channel send"
panic: test timed out after 30s
running tests:
	TestLockInducedDeadlock (30s)

goroutine 7 [running]:
testing.(*M).startAlarm.func1()
	/root/.gvm/gos/go1.20/src/testing/testing.go:2241 +0x3b9
created by time.goFunc
	/root/.gvm/gos/go1.20/src/time/sleep.go:176 +0x32

goroutine 1 [chan receive]:
testing.(*T).Run(0xc0000deb60, {0x1961249?, 0x5285c5?}, 0x1a21f58)
	/root/.gvm/gos/go1.20/src/testing/testing.go:1630 +0x405
testing.runTests.func1(0x28cbec0?)
	/root/.gvm/gos/go1.20/src/testing/testing.go:2036 +0x45
testing.tRunner(0xc0000deb60, 0xc000161c88)
	/root/.gvm/gos/go1.20/src/testing/testing.go:1576 +0x10b
testing.runTests(0xc000136b40?, {0x28b76e0, 0x8, 0x8}, {0x0?, 0x100c000130598?, 0x28cad00?})
	/root/.gvm/gos/go1.20/src/testing/testing.go:2034 +0x489
testing.(*M).Run(0xc000136b40)
	/root/.gvm/gos/go1.20/src/testing/testing.go:1906 +0x63a
main.main()
	_testmain.go:61 +0x1aa

goroutine 27 [chan send]:
github.com/portworx/sched-ops/k8s/core/configmap.(*configMap).Unlock(0xc00016d1f0)
	/root/go/src/github.com/portworx/sched-ops/k8s/core/configmap/configmap_lock_v1.go:61 +0x134
github.com/portworx/sched-ops/k8s/core/configmap.TestLockInducedDeadlock(0x0?)
	/root/go/src/github.com/portworx/sched-ops/k8s/core/configmap/configmap_lock_v1_test.go:24 +0x1b6
testing.tRunner(0xc0000ded00, 0x1a21f58)
	/root/.gvm/gos/go1.20/src/testing/testing.go:1576 +0x10b
created by testing.(*T).Run
	/root/.gvm/gos/go1.20/src/testing/testing.go:1629 +0x3ea

goroutine 28 [sync.Mutex.Lock]:
sync.runtime_SemacquireMutex(0xc00017e000?, 0xe0?, 0xc00017e000?)
	/root/.gvm/gos/go1.20/src/runtime/sema.go:77 +0x26
sync.(*Mutex).lockSlow(0xc00016d220)
	/root/.gvm/gos/go1.20/src/sync/mutex.go:171 +0x165
sync.(*Mutex).Lock(...)
	/root/.gvm/gos/go1.20/src/sync/mutex.go:90
github.com/portworx/sched-ops/k8s/core/configmap.(*configMap).refreshLockV1(0xc00016d1f0, {0x19516ab, 0x8})
	/root/go/src/github.com/portworx/sched-ops/k8s/core/configmap/configmap_lock_v1.go:162 +0x19f
created by github.com/portworx/sched-ops/k8s/core/configmap.(*configMap).LockWithHoldTimeout
	/root/go/src/github.com/portworx/sched-ops/k8s/core/configmap/configmap_lock_v1.go:43 +0x371
exit status 2
FAIL	github.com/portworx/sched-ops/k8s/core/configmap	30.034s
```

With the buffered channel, it passes after my testing sleeps are over:
```
go test -timeout 30s -run ^TestLockInducedDeadlock$

testLock
time="2024-03-08T23:14:49Z" level=info msg="Unlock doing debug sleep"
time="2024-03-08T23:14:57Z" level=info msg="refreshLockV1 entered select refresh.C block"
time="2024-03-08T23:15:05Z" level=info msg="Continuing with unlock, hitting channel send"
time="2024-03-08T23:15:05Z" level=info msg="Unlock moved past channel send"
PASS
ok  	github.com/portworx/sched-ops/k8s/core/configmap	16.031s
```