### PR TITLE
PWX-36557: Checking if either of batch or batchv1beta1 is set as part of batch's initClient().

### DIFF
--- a/k8s/batch/batch.go
+++ b/k8s/batch/batch.go
@@ -92,7 +92,7 @@ func (c *Client) SetConfig(cfg *rest.Config) {
 
 // initClient the k8s client if uninitialized
 func (c *Client) initClient() error {
-	if c.batch != nil && c.batchv1beta1 != nil {
+	if c.batch != nil || c.batchv1beta1 != nil {
 		return nil
 	}
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
We should be checking either of batch or batchv1beta1 instead if both of those to be not nil as part of InitClient.
Either of them will always be set.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-36557

**Special notes for your reviewer**:
We have tested this with storkctl for updating cronjobs with kubeconfig rest configs.
