### PR TITLE
PB-6302: Remove the reinit of client in tektoncd

### DIFF
--- a/k8s/kubevirt/kubevirt.go
+++ b/k8s/kubevirt/kubevirt.go
@@ -138,6 +138,7 @@ func (c *Client) loadClientFromServiceAccount() error {
 	return c.loadClient()
 }
 
+// loadClientFromKubeconfig loads a k8s client from a kubeconfig file
 func (c *Client) loadClientFromKubeconfig(kubeconfig string) error {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
@@ -148,6 +149,7 @@ func (c *Client) loadClientFromKubeconfig(kubeconfig string) error {
 	return c.loadClient()
 }
 
+// loadClient loads the k8s client
 func (c *Client) loadClient() error {
 	if c.config == nil {
 		return fmt.Errorf("rest config is not provided")
@@ -166,6 +168,7 @@ func (c *Client) loadClient() error {
 	return nil
 }
 
+// GetKubevirtClient get kubevirt client
 func (c *Client) GetKubevirtClient() kubecli.KubevirtClient {
 	if err := c.initClient(); err != nil {
 		return nil

--- a/k8s/prometheus/alertmanagerconfig.go
+++ b/k8s/prometheus/alertmanagerconfig.go
@@ -9,23 +9,23 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-// AlertManagerConfig adds receiver to alert manager which is responsible sending alerts
+// AlertManagerConfigOps adds receiver to alert manager which is responsible sending alerts
 type AlertManagerConfigOps interface {
-	// List of alertmanagerconfigs that match the namespace
+	// ListAlertManagerConfigs lists alertmanagerconfigs that match the namespace
 	ListAlertManagerConfigs(namespace string, labelSelectors map[string]string) (*monitoringv1alpha1.AlertmanagerConfigList, error)
-	// Get alertmanagerconfigs that matches the name
+	// GetAlertManagerConfig get alertmanagerconfigs that matches the name
 	GetAlertManagerConfig(name string, namespace string) (*monitoringv1alpha1.AlertmanagerConfig, error)
-	// Create a new alertmanagerconfig
+	// CreateAlertManagerConfig Create a new alertmanagerconfig
 	CreateAlertManagerConfig(*monitoringv1alpha1.AlertmanagerConfig) (*monitoringv1alpha1.AlertmanagerConfig, error)
-	// Update one alertmanagerconfig
+	//UpdateAlertManagerConfig  Update one alertmanagerconfig
 	UpdateAlertManagerConfig(*monitoringv1alpha1.AlertmanagerConfig) (*monitoringv1alpha1.AlertmanagerConfig, error)
-	// Delete one alertmanagerconfig
+	// DeleteAlertManagerConfig Delete one alertmanagerconfigs
 	DeleteAlertManagerConfig(name string, namespace string) error
-	// Delete a list of alertmanagerconfig based on the namespace
+	// DeleteCollectionAlertManagerConfig Delete a list of alertmanagerconfig based on the namespace
 	DeleteCollectionAlertManagerConfig(namespace string, labelSelectors map[string]string) error
 }
 
-// List of alert manager configs that match the namespace
+// ListAlertManagerConfigs  List of alert manager configs that match the namespace
 func (c *Client) ListAlertManagerConfigs(namespace string, labelSelectors map[string]string) (*monitoringv1alpha1.AlertmanagerConfigList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func (c *Client) ListAlertManagerConfigs(namespace string, labelSelectors map[st
 	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(namespace).List(context.TODO(), listOptions(labelSelectors))
 }
 
-// Get one alert manager config
+// GetAlertManagerConfig Get one alert manager config
 func (c *Client) GetAlertManagerConfig(name string, namespace string) (*monitoringv1alpha1.AlertmanagerConfig, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func (c *Client) GetAlertManagerConfig(name string, namespace string) (*monitori
 	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-// Creates a new AlertmanagerConfig in the given namespace, provided the secret is provided
+// CreateAlertManagerConfig Creates a new AlertmanagerConfig in the given namespace, provided the secret is provided
 func (c *Client) CreateAlertManagerConfig(amc *monitoringv1alpha1.AlertmanagerConfig) (*monitoringv1alpha1.AlertmanagerConfig, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
@@ -55,7 +55,7 @@ func (c *Client) CreateAlertManagerConfig(amc *monitoringv1alpha1.AlertmanagerCo
 	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(ns).Create(context.TODO(), amc, metav1.CreateOptions{})
 }
 
-// Updates one alert manager config
+// UpdateAlertManagerConfig  Updates one alert manager config
 func (c *Client) UpdateAlertManagerConfig(amc *monitoringv1alpha1.AlertmanagerConfig) (*monitoringv1alpha1.AlertmanagerConfig, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ func (c *Client) UpdateAlertManagerConfig(amc *monitoringv1alpha1.AlertmanagerCo
 	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(amc.Namespace).Update(context.TODO(), amc, metav1.UpdateOptions{})
 }
 
-// Deletes single alert manager config
+// DeleteAlertManagerConfig Deletes single alert manager config
 func (c *Client) DeleteAlertManagerConfig(name string, namespace string) error {
 	if err := c.initClient(); err != nil {
 		return err
@@ -74,6 +74,7 @@ func (c *Client) DeleteAlertManagerConfig(name string, namespace string) error {
 	})
 }
 
+// DeleteCollectionAlertManagerConfig Deletes a list of alert manager config based on the namespace
 func (c *Client) DeleteCollectionAlertManagerConfig(namespace string, labelSelectors map[string]string) error {
 	if err := c.initClient(); err != nil {
 		return err
@@ -85,6 +86,7 @@ func (c *Client) DeleteCollectionAlertManagerConfig(namespace string, labelSelec
 	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(namespace).DeleteCollection(context.TODO(), deleteOpts, listOptions(labelSelectors))
 }
 
+// listOptions returns a list options with label selectors
 func listOptions(labelSelectors map[string]string) metav1.ListOptions {
 	if labelSelectors != nil {
 		return metav1.ListOptions{

--- a/k8s/prometheus/prometheus.go
+++ b/k8s/prometheus/prometheus.go
@@ -129,6 +129,7 @@ func (c *Client) loadClientFromServiceAccount() error {
 	return c.loadClient()
 }
 
+// loadClientFromKubeconfig load client kubeconfig
 func (c *Client) loadClientFromKubeconfig(kubeconfig string) error {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
@@ -139,6 +140,7 @@ func (c *Client) loadClientFromKubeconfig(kubeconfig string) error {
 	return c.loadClient()
 }
 
+// loadClient loads the k8s client
 func (c *Client) loadClient() error {
 	if c.config == nil {
 		return fmt.Errorf("rest config is not provided")

--- a/k8s/prometheus/prometheus_test.go
+++ b/k8s/prometheus/prometheus_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestInstance tests the Instance function
 func TestInstance(t *testing.T) {
 	Instance()
 

--- a/k8s/storage/storage.go
+++ b/k8s/storage/storage.go
@@ -20,6 +20,7 @@ var (
 type Ops interface {
 	ScOps
 	VolumeAttachmentOps
+	CsiDriverOps
 
 	// SetConfig sets the config and resets the client
 	SetConfig(config *rest.Config)

--- a/k8s/tektoncd/pipeline.go
+++ b/k8s/tektoncd/pipeline.go
@@ -6,6 +6,7 @@ import (
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// pipelineOps is an interface to perform pipeline related operations
 type pipelineOps interface {
 	// CreatePipeline creates a new pipeline
 	CreatePipeline(pipeline *tektonv1.Pipeline, namespace string) (*tektonv1.Pipeline, error)
@@ -19,6 +20,7 @@ type pipelineOps interface {
 	UpdatePipeline(*tektonv1.Pipeline) (*tektonv1.Pipeline, error)
 }
 
+// pipelineRunOps is an interface to perform pipeline run related operations
 type pipelineRunOps interface {
 	// CreatePipelineRun creates a new pipeline run
 	CreatePipelineRun(*tektonv1.PipelineRun) (*tektonv1.PipelineRun, error)
@@ -32,6 +34,7 @@ type pipelineRunOps interface {
 	UpdatePipelineRun(*tektonv1.PipelineRun) (*tektonv1.PipelineRun, error)
 }
 
+// CreatePipeline creates a new pipeline on a given namespace
 func (c Client) CreatePipeline(pipeline *tektonv1.Pipeline, namespace string) (*tektonv1.Pipeline, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -39,6 +42,7 @@ func (c Client) CreatePipeline(pipeline *tektonv1.Pipeline, namespace string) (*
 	return c.V1PipelineClient.Create(context.TODO(), pipeline, k8smetav1.CreateOptions{})
 }
 
+// ListPipelines lists all pipelines in a namespace
 func (c Client) ListPipelines(namespace string) (*tektonv1.PipelineList, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -46,6 +50,7 @@ func (c Client) ListPipelines(namespace string) (*tektonv1.PipelineList, error) 
 	return c.V1PipelineClient.List(context.TODO(), k8smetav1.ListOptions{})
 }
 
+// GetPipeline gets a pipeline by name on a given namespace
 func (c Client) GetPipeline(namespace, name string) (*tektonv1.Pipeline, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -53,6 +58,7 @@ func (c Client) GetPipeline(namespace, name string) (*tektonv1.Pipeline, error) 
 	return c.V1PipelineClient.Get(context.TODO(), name, k8smetav1.GetOptions{})
 }
 
+// DeletePipeline deletes a pipeline by name on a given namespace
 func (c Client) DeletePipeline(namespace, name string) error {
 	if err := c.initClient(namespace); err != nil {
 		return err
@@ -60,6 +66,7 @@ func (c Client) DeletePipeline(namespace, name string) error {
 	return c.V1PipelineClient.Delete(context.TODO(), name, k8smetav1.DeleteOptions{})
 }
 
+// UpdatePipeline updates a pipeline
 func (c Client) UpdatePipeline(pipeline *tektonv1.Pipeline) (*tektonv1.Pipeline, error) {
 	if err := c.initClient(pipeline.Namespace); err != nil {
 		return nil, err
@@ -67,6 +74,7 @@ func (c Client) UpdatePipeline(pipeline *tektonv1.Pipeline) (*tektonv1.Pipeline,
 	return c.V1PipelineClient.Update(context.TODO(), pipeline, k8smetav1.UpdateOptions{})
 }
 
+// CreatePipelineRun creates a new pipeline run
 func (c Client) CreatePipelineRun(pipelineRun *tektonv1.PipelineRun) (*tektonv1.PipelineRun, error) {
 	if err := c.initClient(pipelineRun.Namespace); err != nil {
 		return nil, err
@@ -74,6 +82,7 @@ func (c Client) CreatePipelineRun(pipelineRun *tektonv1.PipelineRun) (*tektonv1.
 	return c.V1PipelineRunClient.Create(context.TODO(), pipelineRun, k8smetav1.CreateOptions{})
 }
 
+// ListPipelineRuns lists all pipeline runs in a namespace
 func (c Client) ListPipelineRuns(namespace string) (*tektonv1.PipelineRunList, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -81,6 +90,7 @@ func (c Client) ListPipelineRuns(namespace string) (*tektonv1.PipelineRunList, e
 	return c.V1PipelineRunClient.List(context.TODO(), k8smetav1.ListOptions{})
 }
 
+// GetPipelineRun gets a pipeline run by name on a given namespace
 func (c Client) GetPipelineRun(namespace, name string) (*tektonv1.PipelineRun, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -88,6 +98,7 @@ func (c Client) GetPipelineRun(namespace, name string) (*tektonv1.PipelineRun, e
 	return c.V1PipelineRunClient.Get(context.TODO(), name, k8smetav1.GetOptions{})
 }
 
+// DeletePipelineRun deletes a pipeline run by name on a given namespace
 func (c Client) DeletePipelineRun(namespace, name string) error {
 	if err := c.initClient(namespace); err != nil {
 		return err
@@ -95,6 +106,7 @@ func (c Client) DeletePipelineRun(namespace, name string) error {
 	return c.V1PipelineRunClient.Delete(context.TODO(), name, k8smetav1.DeleteOptions{})
 }
 
+// UpdatePipelineRun updates a pipeline run
 func (c Client) UpdatePipelineRun(pipelineRun *tektonv1.PipelineRun) (*tektonv1.PipelineRun, error) {
 	if err := c.initClient(pipelineRun.Namespace); err != nil {
 		return nil, err

--- a/k8s/tektoncd/task.go
+++ b/k8s/tektoncd/task.go
@@ -6,6 +6,7 @@ import (
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// taskOps is an interface to perform task related operations
 type taskOps interface {
 	// CreateTask creates a new task
 	CreateTask(task *tektonv1.Task, namespace string) (*tektonv1.Task, error)
@@ -19,6 +20,7 @@ type taskOps interface {
 	UpdateTask(*tektonv1.Task) (*tektonv1.Task, error)
 }
 
+// taskRunOps is an interface to perform task run related operations
 type taskRunOps interface {
 	// CreateTaskRun creates a new task run
 	CreateTaskRun(*tektonv1.TaskRun) (*tektonv1.TaskRun, error)
@@ -32,6 +34,7 @@ type taskRunOps interface {
 	UpdateTaskRun(*tektonv1.TaskRun) (*tektonv1.TaskRun, error)
 }
 
+// CreateTask creates a new task on a given namespace
 func (c *Client) CreateTask(task *tektonv1.Task, namespace string) (*tektonv1.Task, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -39,6 +42,7 @@ func (c *Client) CreateTask(task *tektonv1.Task, namespace string) (*tektonv1.Ta
 	return c.V1TaskClient.Create(context.TODO(), task, k8smetav1.CreateOptions{})
 }
 
+// ListTasks lists all tasks in a namespace
 func (c *Client) ListTasks(namespace string) (*tektonv1.TaskList, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -46,6 +50,7 @@ func (c *Client) ListTasks(namespace string) (*tektonv1.TaskList, error) {
 	return c.V1TaskClient.List(context.TODO(), k8smetav1.ListOptions{})
 }
 
+// GetTask gets a task by name on a given namespace
 func (c *Client) GetTask(namespace, name string) (*tektonv1.Task, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -53,6 +58,7 @@ func (c *Client) GetTask(namespace, name string) (*tektonv1.Task, error) {
 	return c.V1TaskClient.Get(context.TODO(), name, k8smetav1.GetOptions{})
 }
 
+// DeleteTask deletes a task by name on a given namespace
 func (c *Client) DeleteTask(namespace, name string) error {
 	if err := c.initClient(namespace); err != nil {
 		return err
@@ -60,6 +66,7 @@ func (c *Client) DeleteTask(namespace, name string) error {
 	return c.V1TaskClient.Delete(context.TODO(), name, k8smetav1.DeleteOptions{})
 }
 
+// UpdateTask updates a task
 func (c *Client) UpdateTask(task *tektonv1.Task) (*tektonv1.Task, error) {
 	if err := c.initClient(task.Namespace); err != nil {
 		return nil, err
@@ -67,6 +74,7 @@ func (c *Client) UpdateTask(task *tektonv1.Task) (*tektonv1.Task, error) {
 	return c.V1TaskClient.Update(context.TODO(), task, k8smetav1.UpdateOptions{})
 }
 
+// CreateTaskRun creates a new task run
 func (c *Client) CreateTaskRun(taskRun *tektonv1.TaskRun) (*tektonv1.TaskRun, error) {
 	if err := c.initClient(taskRun.Namespace); err != nil {
 		return nil, err
@@ -74,6 +82,7 @@ func (c *Client) CreateTaskRun(taskRun *tektonv1.TaskRun) (*tektonv1.TaskRun, er
 	return c.V1TaskRunClient.Create(context.TODO(), taskRun, k8smetav1.CreateOptions{})
 }
 
+// ListTaskRuns lists all task runs in a namespace
 func (c *Client) ListTaskRuns(namespace string) (*tektonv1.TaskRunList, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -81,6 +90,7 @@ func (c *Client) ListTaskRuns(namespace string) (*tektonv1.TaskRunList, error) {
 	return c.V1TaskRunClient.List(context.TODO(), k8smetav1.ListOptions{})
 }
 
+// GetTaskRun gets a task run by name on a given namespace
 func (c *Client) GetTaskRun(namespace, name string) (*tektonv1.TaskRun, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -88,6 +98,7 @@ func (c *Client) GetTaskRun(namespace, name string) (*tektonv1.TaskRun, error) {
 	return c.V1TaskRunClient.Get(context.TODO(), name, k8smetav1.GetOptions{})
 }
 
+// DeleteTaskRun deletes a task run by name on a given namespace
 func (c *Client) DeleteTaskRun(namespace, name string) error {
 	if err := c.initClient(namespace); err != nil {
 		return err
@@ -95,6 +106,7 @@ func (c *Client) DeleteTaskRun(namespace, name string) error {
 	return c.V1TaskRunClient.Delete(context.TODO(), name, k8smetav1.DeleteOptions{})
 }
 
+// UpdateTaskRun updates a task run
 func (c *Client) UpdateTaskRun(taskRun *tektonv1.TaskRun) (*tektonv1.TaskRun, error) {
 	if err := c.initClient(taskRun.Namespace); err != nil {
 		return nil, err

--- a/k8s/tektoncd/tektoncd.go
+++ b/k8s/tektoncd/tektoncd.go
@@ -97,7 +97,7 @@ func (c *Client) SetConfig(cfg *rest.Config) {
 
 // initClient the k8s client if uninitialized
 func (c *Client) initClient(namespace string) error {
-	// As the client needs to be intialized for
+	// As the client needs to be intialized for each namespace created and passed
 	return c.setClient(namespace)
 }
 

--- a/k8s/tektoncd/tektoncd.go
+++ b/k8s/tektoncd/tektoncd.go
@@ -97,10 +97,7 @@ func (c *Client) SetConfig(cfg *rest.Config) {
 
 // initClient the k8s client if uninitialized
 func (c *Client) initClient(namespace string) error {
-	if c.V1PipelineClient != nil || c.V1TaskClient != nil || c.V1TaskRunClient != nil || c.V1PipelineRunClient != nil {
-		return nil
-	}
-
+	// As the client needs to be intialized for
 	return c.setClient(namespace)
 }
 
@@ -132,6 +129,7 @@ func (c *Client) loadClientFromServiceAccount(namespace string) error {
 	return c.loadClient(namespace)
 }
 
+// loadClientFromKubeconfig loads a k8s client from a kubeconfig file
 func (c *Client) loadClientFromKubeconfig(kubeconfig string, namespace string) error {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
@@ -142,6 +140,7 @@ func (c *Client) loadClientFromKubeconfig(kubeconfig string, namespace string) e
 	return c.loadClient(namespace)
 }
 
+// loadClient loads the k8s client
 func (c *Client) loadClient(namespace string) error {
 	if c.config == nil {
 		return fmt.Errorf("rest config is not provided")


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- [x] Remove reuse of client in tektoncd
- [x] Fix golint issues created by the pervious PRs.  


Successful run where we are testing the changes:
https://aetos.pwx.purestorage.com/resultSet/testSetID/589435 

**Which issue(s) this PR fixes** (optional)
Closes #PB-6302

**Special notes for your reviewer**:

