### PR TITLE
PWX-36900: WatchNode should watch all the nodes when no node is passed to the function

### DIFF
--- a/k8s/core/nodes.go
+++ b/k8s/core/nodes.go
@@ -288,19 +288,17 @@ func (c *Client) RemoveLabelOnNode(name, key string) error {
 
 // WatchNode sets up a watcher that listens for the changes on Node.
 func (c *Client) WatchNode(node *corev1.Node, watchNodeFn WatchFunc) error {
-	if node == nil {
-		return fmt.Errorf("no node given to watch")
-	}
-
 	if err := c.initClient(); err != nil {
 		return err
 	}
-
 	listOptions := metav1.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector("metadata.name", node.Name).String(),
-		Watch:         true,
+		Watch: true,
 	}
-
+	if node != nil {
+		listOptions.FieldSelector = fields.OneTermEqualSelector("metadata.name", node.Name).String()
+	} else {
+		fmt.Printf("Watching all nodes")
+	}
 	watchInterface, err := c.kubernetes.CoreV1().Nodes().Watch(context.TODO(), listOptions)
 	if err != nil {
 		return err
@@ -309,6 +307,7 @@ func (c *Client) WatchNode(node *corev1.Node, watchNodeFn WatchFunc) error {
 	// fire off watch function
 	go c.handleWatch(watchInterface, node, "", watchNodeFn, listOptions)
 	return nil
+
 }
 
 // CordonNode cordons the given node


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Changed implementation of WatchNode function such that if no node is passed as an input it should watch all the nodes and should not return error

**Which issue(s) this PR fixes** (optional)
Closes # PWX-36900

Testing:
<img width="1725" alt="Screenshot 2024-04-24 at 9 57 52 AM" src="https://github.com/portworx/sched-ops/assets/141733833/422c4c68-3fa9-44e2-bf80-5406ffec017f">



