### PR TITLE
PWX-37013: WatchNode should watch all the nodes when no node is passed to the function

### DIFF
--- a/k8s/core/nodes.go
+++ b/k8s/core/nodes.go
@@ -286,21 +286,19 @@ func (c *Client) RemoveLabelOnNode(name, key string) error {
 	return err
 }
 
-// WatchNode sets up a watcher that listens for the changes on Node.
+// WatchNode sets up a watcher that listens for the changes on input node and will watch all the nodes when input node is nil.
 func (c *Client) WatchNode(node *corev1.Node, watchNodeFn WatchFunc) error {
-	if node == nil {
-		return fmt.Errorf("no node given to watch")
-	}
-
 	if err := c.initClient(); err != nil {
 		return err
 	}
-
 	listOptions := metav1.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector("metadata.name", node.Name).String(),
-		Watch:         true,
+		Watch: true,
 	}
-
+	if node != nil {
+		listOptions.FieldSelector = fields.OneTermEqualSelector("metadata.name", node.Name).String()
+	} else {
+		fmt.Printf("Watching all nodes")
+	}
 	watchInterface, err := c.kubernetes.CoreV1().Nodes().Watch(context.TODO(), listOptions)
 	if err != nil {
 		return err

--- a/k8s/core/nodes.go
+++ b/k8s/core/nodes.go
@@ -307,6 +307,7 @@ func (c *Client) WatchNode(node *corev1.Node, watchNodeFn WatchFunc) error {
 	// fire off watch function
 	go c.handleWatch(watchInterface, node, "", watchNodeFn, listOptions)
 	return nil
+
 }
 
 // CordonNode cordons the given node


### PR DESCRIPTION

What this PR does / why we need it:
Changed implementation of WatchNode function such that if no node is passed as an input it should watch all the nodes and should not return error

Which issue(s) this PR fixes (optional)
Closes # PWX-37013

Testing:
<img width="1725" alt="Screenshot 2024-04-24 at 9 57 52 AM" src="https://github.com/portworx/sched-ops/assets/141733833/e9601c93-f650-45db-90ff-e8f11858ea36">




