### PR TITLE
check VM status Ready along with Printable status

### DIFF
--- a/k8s/kubevirt/virtualmachine.go
+++ b/k8s/kubevirt/virtualmachine.go
@@ -150,7 +150,7 @@ func (c *Client) ValidateVirtualMachineRunning(name, namespace string, timeout, 
 			return "", false, fmt.Errorf("failed to get Virtual Machine")
 		}
 
-		if vm.Status.PrintableStatus == kubevirtv1.VirtualMachineStatusRunning {
+		if vm.Status.PrintableStatus == kubevirtv1.VirtualMachineStatusRunning && vm.Status.Ready == true {
 			return "", false, nil
 		}
 		return "", true, fmt.Errorf("Virtual Machine not in running state: %v", vm.Status.PrintableStatus)


### PR DESCRIPTION
**What this PR does / why we need it**:
* Current way of checking if VM is ready is incorrect
* VM status should also be checked to be `Ready` to certify that a VM is running

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

