### PR TITLE
PWX-34271: handle a failed VMI migration with no migrationState

### DIFF
--- a/k8s/kubevirt-dynamic/virtualmachineinstancemigration.go
+++ b/k8s/kubevirt-dynamic/virtualmachineinstancemigration.go
@@ -10,6 +10,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+const (
+	// migrationPhaseFailed is the phase when the migration has failed
+	migrationPhaseFailed = "Failed"
+)
+
 var (
 	migrationResource = schema.GroupVersionResource{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachineinstancemigrations"}
 )
@@ -220,7 +225,7 @@ func (c *Client) unstructuredGetVMIMigration(
 		return nil, fmt.Errorf("failed to get 'completed' from the vmi migration status: %w", err)
 	}
 	// migrationState is not present if the pod fails to get scheduled; we need to look at the Phase
-	if !found && ret.Phase == "Failed" {
+	if !found && ret.Phase == migrationPhaseFailed {
 		ret.Completed = true
 	}
 	// failed
@@ -229,7 +234,7 @@ func (c *Client) unstructuredGetVMIMigration(
 		return nil, fmt.Errorf("failed to get 'failed' from the vmi migration status: %w", err)
 	}
 	// migrationState is not present if the pod fails to get scheduled; we need to look at the Phase
-	if !found && ret.Phase == "Failed" {
+	if !found && ret.Phase == migrationPhaseFailed {
 		ret.Failed = true
 	}
 	// startTimestamp


### PR DESCRIPTION
**What this PR does / why we need it**:

If the virt-launcher pod fails to get scheduled, VMI migration phase is changed to "Failed" but no migrationState is added to status. We were relying solely on migrationState to detect if the migration has completed. Now, we look at the Phase as well.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->



**Which issue(s) this PR fixes** (optional)
PWX-34271

**Special notes for your reviewer**:

