### PR TITLE
PWX-34271: expose ready and paused conditions in kubevirt-dynamic VMI

### DIFF
--- a/k8s/kubevirt-dynamic/kubevirt.go
+++ b/k8s/kubevirt-dynamic/kubevirt.go
@@ -270,3 +270,22 @@ func (c *Client) unstructuredGetTimestamp(obj map[string]interface{}, fields ...
 	}
 	return ret, found, nil
 }
+
+func (c *Client) getBoolCondition(conditions []interface{}, conditionType string) (bool, bool, error) {
+	condition, err := c.unstructuredFindKeyValString(conditions, "type", conditionType)
+	if err != nil {
+		return false, false, fmt.Errorf("failed while finding %s condition in vmi: %w", conditionType, err)
+	}
+	if condition != nil {
+		val, found, err := c.unstructuredGetValString(condition, "status")
+		if err != nil || !found {
+			return false, false, fmt.Errorf("failed to get status of %s condition: %w", conditionType, err)
+		}
+		boolVal, err := strconv.ParseBool(val)
+		if err != nil {
+			return false, false, fmt.Errorf("failed to parse status for %s condition: %w", conditionType, err)
+		}
+		return boolVal, true, nil
+	}
+	return false, false, nil
+}

--- a/k8s/kubevirt-dynamic/virtualmachineinstance_test.go
+++ b/k8s/kubevirt-dynamic/virtualmachineinstance_test.go
@@ -28,6 +28,7 @@ func TestGetVMI(t *testing.T) {
 		t.FailNow()
 	}
 	t.Logf("VMI: %v", vmi)
+	t.Logf("LiveMigratable=%v, Ready=%v, Paused=%v", vmi.LiveMigratable, vmi.Ready, vmi.Paused)
 	for _, phaseTransition := range vmi.PhaseTransitions {
 		t.Logf("PhaseTransition: %v", phaseTransition)
 	}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
PWX-34271

**Special notes for your reviewer**:

