### PR TITLE
Adding default namespaces for machines objects

### DIFF
--- a/k8s/anthos/machines.go
+++ b/k8s/anthos/machines.go
@@ -14,6 +14,10 @@ var (
 	machineResource = schema.GroupVersionResource{Group: "cluster.k8s.io", Version: "v1alpha1", Resource: "machines"}
 )
 
+const (
+	DefaultNamespace = "default"
+)
+
 // MachinesOps is an interface to perform k8s machines operations
 type MachineOps interface {
 	// ListMachines lists all machines in kubernetes cluster
@@ -30,7 +34,7 @@ func (c *Client) ListMachines(ctx context.Context) (*v1alpha1.MachineList, error
 		return nil, err
 	}
 
-	result, err := c.dynamicClient.Resource(machineResource).List(ctx, metav1.ListOptions{})
+	result, err := c.dynamicClient.Resource(machineResource).Namespace(DefaultNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +55,7 @@ func (c *Client) GetMachine(ctx context.Context, name string) (*v1alpha1.Machine
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	rawMachine, err := c.dynamicClient.Resource(machineResource).Get(ctx, name, metav1.GetOptions{})
+	rawMachine, err := c.dynamicClient.Resource(machineResource).Namespace(DefaultNamespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -71,6 +75,6 @@ func (c *Client) DeleteMachine(ctx context.Context, name string) error {
 	if err := c.initClient(); err != nil {
 		return err
 	}
-	return c.dynamicClient.Resource(machineResource).Delete(ctx, name, metav1.DeleteOptions{})
+	return c.dynamicClient.Resource(machineResource).Namespace(DefaultNamespace).Delete(ctx, name, metav1.DeleteOptions{})
 
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
FIxing the namespace for machines object 

**Which issue(s) this PR fixes** (optional)
Closes # PTX-23757

**Special notes for your reviewer**:
Minor change

```
2024-05-23 18:32:46 +0000:[INFO] [{ASGKillRandomNodes}] Randomly kill one storage node
2024-05-23 18:32:46 +0000:[INFO] [{ASGKillRandomNodes}] Deleting node [pool-0-cb8677c59-m2qkj]
2024-05-23 18:32:46 +0000:[INFO] [{ASGKillRandomNodes}] [anthos.(*anthos).getUserClusterName:#638] - Retrieving user cluster name
2024-05-23 18:32:46 +0000:[DEBUG] [{ASGKillRandomNodes}] [ssh.(*SSH).getConnectionOnUsableAddr:#842] - checking for usable address in: [10.13.11.226] for node [10.13.11.226]
2024-05-23 18:32:46 +0000:[DEBUG] [{ASGKillRandomNodes}] [ssh.(*SSH).getConnectionOnUsableAddr:#852] - usable address: [10.13.11.226] for node [10.13.11.226]
2024-05-23 18:32:46 +0000:[INFO] [{ASGKillRandomNodes}] [anthos.(*anthos).getUserClusterName:#655] - Successfully retrieved user cluster name: [tp-nextpx-anthos-op]
2024-05-23 18:32:46 +0000:[INFO] [{ASGKillRandomNodes}] [anthos.(*anthos).DeleteNode:#988] - Deleted node [pool-0-cb8677c59-m2qkj] from anthos cluster: [tp-nextpx-anthos-op] 
INFO[2024-05-23 18:32:46] Verifying : Description : Valdiate node pool-0-cb8677c59-m2qkj deletion 
INFO[2024-05-23 18:32:46] Actual:true, Expected: true          
```

Snip of machines in k8s cluster
```
[root@k8sjenkins-agent09 clusterGroup0]# kubectl get machines -A -w
NAMESPACE   NAME
default     pool-0-cb8677c59-4crbq
default     pool-0-cb8677c59-6lznl
default     pool-0-cb8677c59-c742p
default     pool-0-cb8677c59-m2qkj
default     pool-0-cb8677c59-pkj44
default     tp-nextpx-anthos-op-44fc5w247c9fzz9b-0
^C[root@k8sjenkins-agent09 clusterGroup0]# kubectl get machines -A -w
NAMESPACE   NAME
default     pool-0-cb8677c59-4crbq
default     pool-0-cb8677c59-6lznl
default     pool-0-cb8677c59-c742p
default     pool-0-cb8677c59-m2qkj
default     pool-0-cb8677c59-pkj44
default     tp-nextpx-anthos-op-44fc5w247c9fzz9b-0
^[[Adefault     pool-0-cb8677c59-m2qkj
^C[root@k8sjenkins-agent09 clusterGroup0]# kubectl  get nodes -A
NAME                     STATUS                        ROLES                  AGE   VERSION
anthos-user-cp-vm-0      Ready                         control-plane,master   17h   v1.29.3-gke.600
pool-0-cb8677c59-4crbq   Ready                         <none>                 16h   v1.29.3-gke.600
pool-0-cb8677c59-6lznl   Ready                         <none>                 16h   v1.29.3-gke.600
pool-0-cb8677c59-c742p   Ready                         <none>                 16h   v1.29.3-gke.600
pool-0-cb8677c59-m2qkj   NotReady,SchedulingDisabled   <none>                 16h   v1.29.3-gke.600
pool-0-cb8677c59-pkj44   Ready                         <none>                 16h   v1.29.3-gke.600
[root@k8sjenkins-agent09 clusterGroup0]# kubectl get machines -A -w -o wide
NAMESPACE   NAME                                     NODENAME
default     pool-0-cb8677c59-4crbq                   pool-0-cb8677c59-4crbq
default     pool-0-cb8677c59-6lznl                   pool-0-cb8677c59-6lznl
default     pool-0-cb8677c59-c742p                   pool-0-cb8677c59-c742p
default     pool-0-cb8677c59-m2qkj                   pool-0-cb8677c59-m2qkj
default     pool-0-cb8677c59-pkj44                   pool-0-cb8677c59-pkj44
default     tp-nextpx-anthos-op-44fc5w247c9fzz9b-0   anthos-user-cp-vm-0
default     pool-0-cb8677c59-m2qkj                   pool-0-cb8677c59-m2qkj
default     pool-0-cb8677c59-m2qkj                   pool-0-cb8677c59-m2qkj
default     pool-0-cb8677c59-m2qkj                   pool-0-cb8677c59-m2qkj
default     pool-0-cb8677c59-m2qkj                   pool-0-cb8677c59-m2qkj
default     pool-0-cb8677c59-p4rg4                   
default     pool-0-cb8677c59-p4rg4                   
default     pool-0-cb8677c59-p4rg4                   
default     pool-0-cb8677c59-p4rg4                   
default     pool-0-cb8677c59-p4rg4                   
^C[root@k8sjenkins-agent09 clusterGroup0]# kubectl  get nodes -A
NAME                     STATUS   ROLES                  AGE   VERSION
anthos-user-cp-vm-0      Ready    control-plane,master   17h   v1.29.3-gke.600
pool-0-cb8677c59-4crbq   Ready    <none>                 16h   v1.29.3-gke.600
pool-0-cb8677c59-6lznl   Ready    <none>                 16h   v1.29.3-gke.600
pool-0-cb8677c59-c742p   Ready    <none>                 16h   v1.29.3-gke.600
pool-0-cb8677c59-pkj44   Ready    <none>                 16h   v1.29.3-gke.600
[root@k8sjenkins-agent09 clusterGroup0]# kubectl get machines -A -w -o wide
NAMESPACE   NAME                                     NODENAME
default     pool-0-cb8677c59-4crbq                   pool-0-cb8677c59-4crbq
default     pool-0-cb8677c59-6lznl                   pool-0-cb8677c59-6lznl
default     pool-0-cb8677c59-c742p                   pool-0-cb8677c59-c742p
default     pool-0-cb8677c59-p4rg4                   
default     pool-0-cb8677c59-pkj44                   pool-0-cb8677c59-pkj44
default     tp-nextpx-anthos-op-44fc5w247c9fzz9b-0   anthos-user-cp-vm-0
default     pool-0-cb8677c59-p4rg4                   
default     pool-0-cb8677c59-p4rg4                   
^C[root@k8sjenkins-agent09 clusterGroup0]# kubectl get machines -A -w -o wide
NAMESPACE   NAME                                     NODENAME
default     pool-0-cb8677c59-4crbq                   pool-0-cb8677c59-4crbq
default     pool-0-cb8677c59-6lznl                   pool-0-cb8677c59-6lznl
default     pool-0-cb8677c59-c742p                   pool-0-cb8677c59-c742p
default     pool-0-cb8677c59-p4rg4                   
default     pool-0-cb8677c59-pkj44                   pool-0-cb8677c59-pkj44
default     tp-nextpx-anthos-op-44fc5w247c9fzz9b-0   anthos-user-cp-vm-0
^[[Adefault     pool-0-cb8677c59-p4rg4                   
default     pool-0-cb8677c59-4crbq                   pool-0-cb8677c59-4crbq
default     pool-0-cb8677c59-p4rg4                   
default     pool-0-cb8677c59-p4rg4                   
default     pool-0-cb8677c59-p4rg4                   
^C[root@k8sjenkins-agent09 clusterGroup0]# kubectl  get nodes -A
NAME                     STATUS     ROLES                  AGE   VERSION
anthos-user-cp-vm-0      Ready      control-plane,master   17h   v1.29.3-gke.600
pool-0-cb8677c59-4crbq   Ready      <none>                 16h   v1.29.3-gke.600
pool-0-cb8677c59-6lznl   Ready      <none>                 16h   v1.29.3-gke.600
pool-0-cb8677c59-c742p   Ready      <none>                 16h   v1.29.3-gke.600
pool-0-cb8677c59-p4rg4   NotReady   <none>                 5s    v1.29.3-gke.600
pool-0-cb8677c59-pkj44   Ready      <none>                 16h   v1.29.3-gke.600
[root@k8sjenkins-agent09 clusterGroup0]# kubectl get machines -A -w -o wide
NAMESPACE   NAME                                     NODENAME
default     pool-0-cb8677c59-4crbq                   pool-0-cb8677c59-4crbq
default     pool-0-cb8677c59-6lznl                   pool-0-cb8677c59-6lznl
default     pool-0-cb8677c59-c742p                   pool-0-cb8677c59-c742p
default     pool-0-cb8677c59-p4rg4                   
default     pool-0-cb8677c59-pkj44                   pool-0-cb8677c59-pkj44
default     tp-nextpx-anthos-op-44fc5w247c9fzz9b-0   anthos-user-cp-vm-0
default     pool-0-cb8677c59-p4rg4                   pool-0-cb8677c59-p4rg4
default     pool-0-cb8677c59-p4rg4                   pool-0-cb8677c59-p4rg4
^C[root@k8sjenkins-agent09 clusterGroup0]# kubectl get machines -A 
NAMESPACE   NAME
default     pool-0-cb8677c59-4crbq
default     pool-0-cb8677c59-6lznl
default     pool-0-cb8677c59-c742p
default     pool-0-cb8677c59-p4rg4
default     pool-0-cb8677c59-pkj44
default     tp-nextpx-anthos-op-44fc5w247c9fzz9b-0
[root@k8sjenkins-agent09 clusterGroup0]#
```
