### PR TITLE
PWX-37466: handle missing migrationState for a succeeded VM live-migr…

### DIFF
--- a/k8s/kubevirt-dynamic/virtualmachineinstancemigration.go
+++ b/k8s/kubevirt-dynamic/virtualmachineinstancemigration.go
@@ -13,6 +13,8 @@ import (
 const (
 	// migrationPhaseFailed is the phase when the migration has failed
 	migrationPhaseFailed = "Failed"
+	// migrationPhaseSucceeded is the phase when the migration has succeeded
+	migrationPhaseSucceeded = "Succeeded"
 )
 
 var (
@@ -224,8 +226,8 @@ func (c *Client) unstructuredGetVMIMigration(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get 'completed' from the vmi migration status: %w", err)
 	}
-	// migrationState is not present if the pod fails to get scheduled; we need to look at the Phase
-	if !found && ret.Phase == migrationPhaseFailed {
+	// sometimes migrationState is not present; we need to look at the Phase
+	if !found && (ret.Phase == migrationPhaseFailed || ret.Phase == migrationPhaseSucceeded) {
 		ret.Completed = true
 	}
 	// failed


### PR DESCRIPTION
…ation

**What this PR does / why we need it**:

migrationState can be missing even for a successful live migration. If the phase is "Succeeded", we mark the migration as completed.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->



**Which issue(s) this PR fixes** (optional)
PWX-37466

**Special notes for your reviewer**:

