### PR TITLE
Added logic to proceed if VM is already Running while validating

### DIFF
--- a/k8s/kubevirt/virtualmachine.go
+++ b/k8s/kubevirt/virtualmachine.go
@@ -3,6 +3,7 @@ package kubevirt
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/portworx/sched-ops/task"
@@ -145,7 +146,12 @@ func (c *Client) ValidateVirtualMachineRunning(name, namespace string, timeout, 
 	if runStrategy != kubevirtv1.RunStrategyAlways && (vm.Status.PrintableStatus == kubevirtv1.VirtualMachineStatusStopped ||
 		vm.Status.PrintableStatus == kubevirtv1.VirtualMachineStatusStopping) {
 		if err = c.StartVirtualMachine(vm); err != nil {
-			return fmt.Errorf("failed to start VirtualMachine %s/%s: %w", namespace, name, err)
+			if strings.Contains(err.Error(), "VM is already running") {
+				// Proceed if the VM is already running
+				fmt.Printf("VM [%s] in namespace [%s] is already running, proceeding with validation", vm.Name, vm.Namespace)
+			} else {
+				return fmt.Errorf("failed to start VirtualMachine: %v", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
This is because of inconsistent behaviour from Kubevirt.
While validating Virtual Machines in Torpedo, what we are doing is, checking that the field printableStatus  should not be in Stopped  or Stopping  state. If it is in one of those states, we are Starting the VM. This is the logic
```
// Start the VirtualMachine if its not Started yet
	if vm.Status.PrintableStatus == kubevirtv1.VirtualMachineStatusStopped ||
		vm.Status.PrintableStatus == kubevirtv1.VirtualMachineStatusStopping {
		if err = c.StartVirtualMachine(vm); err != nil {
			return fmt.Errorf("Failed to start VirtualMachine %v", err)
		}
	}
```
This logic is fine, but once in a while Kubevirt makes the VM go into Stopped state for a millisecond before it goes into Starting  state. In such cases we are entering the if  block and trying to start the VM. Now kubevirt has this logic where, if you are trying to start a VM which is already Starting  or Running  it will throw on error as follows:
`Failed to start VirtualMachine Operation cannot be fulfilled on virtualmachine.kubevirt.io "cirrosvm": VM is already running
`

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

