### PR TITLE
PWX-38237: pick the first PVC or dataVolume as VMI rootdisk when boot…

### DIFF
--- a/k8s/kubevirt-dynamic/kubevirt.go
+++ b/k8s/kubevirt-dynamic/kubevirt.go
@@ -241,6 +241,27 @@ func (c *Client) unstructuredFindKeyValInt64(
 	return nil, nil
 }
 
+// unstructuredGetStringValuesForKey scans the specified slice of maps and returns string values
+// for the specified key.
+// The input slice members are expected to be of type map[string]interface{}.
+func (c *Client) unstructuredGetStringValuesForKey(data []interface{}, key string) ([]string, error) {
+	var ret []string
+	for _, rawMap := range data {
+		typedMap, ok := rawMap.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("wrong type of element in slice: expected map[string]interface{}, actual %T", rawMap)
+		}
+		mapVal, found, err := c.unstructuredGetValString(typedMap, key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get key %q in map in the slice", key)
+		} else if !found {
+			continue
+		}
+		ret = append(ret, mapVal)
+	}
+	return ret, nil
+}
+
 func (c *Client) unstructuredGetStringAsBool(obj map[string]interface{}, fields ...string) (bool, bool, error) {
 	ret := false
 	val, found, err := unstructured.NestedString(obj, fields...)

--- a/k8s/kubevirt-dynamic/virtualmachineinstance.go
+++ b/k8s/kubevirt-dynamic/virtualmachineinstance.go
@@ -74,7 +74,10 @@ func (c *Client) GetVirtualMachineInstance(
 	if err != nil {
 		return nil, err
 	}
-	// Find name of the root disk (one with bootOrder=1) in VMI. Sample yaml:
+	// Find name of the root disk (one with bootOrder=1) in VMI. If bootOrder is not present, find the first
+	// PVC or a dataVolume and treat it as a root disk.
+	//
+	// Sample yaml:
 	//spec:
 	//  domain:
 	//    devices:
@@ -95,23 +98,23 @@ func (c *Client) GetVirtualMachineInstance(
 	if err != nil || !found || len(disks) == 0 {
 		return nil, fmt.Errorf("failed to find vmi disks: %w", err)
 	}
-	rootDiskName := ""
+	var rootDiskCandidates []string
 	bootDisk, err := c.unstructuredFindKeyValInt64(disks, "bootOrder", 1)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find boot disk in vmi: %w", err)
 	}
-	if bootDisk == nil {
-		// No "bootOrder" present in the VM spec. Assume that the first disk is the boot disk.
-		var ok bool
-		rawMap := disks[0]
-		bootDisk, ok = rawMap.(map[string]interface{})
-		if !ok {
-			return nil, fmt.Errorf("wrong type of element in slice: expected map[string]interface{}, actual %T", rawMap)
+	if bootDisk != nil {
+		rootDiskName, found, err := c.unstructuredGetValString(bootDisk, "name")
+		if err != nil || !found || rootDiskName == "" {
+			return nil, fmt.Errorf("failed to find rootDisk name: %w", err)
 		}
-	}
-	rootDiskName, found, err = c.unstructuredGetValString(bootDisk, "name")
-	if err != nil || !found || rootDiskName == "" {
-		return nil, fmt.Errorf("failed to find rootDisk name: %w", err)
+		rootDiskCandidates = append(rootDiskCandidates, rootDiskName)
+	} else {
+		// no bootOrder. Gather all the disk names.
+		rootDiskCandidates, err = c.unstructuredGetStringValuesForKey(disks, "name")
+		if err != nil {
+			return nil, fmt.Errorf("bootOrder is not present and failed to find disk names: %w", err)
+		}
 	}
 	// Find name of the PVC in VMI. Sample yaml when dataVolume was used by the VMI:
 	// NOTE: the dataVolume may have been garbage collected after pvc was ready.
@@ -125,40 +128,49 @@ func (c *Client) GetVirtualMachineInstance(
 	if err != nil || !found {
 		return nil, fmt.Errorf("failed to find vmi volumes: %w", err)
 	}
-	pvcName := ""
-	rootVolume, err := c.unstructuredFindKeyValString(volumes, "name", rootDiskName)
-	if err != nil || rootVolume == nil {
-		return nil, fmt.Errorf("failed to find root volume %q in the vmi: %w", rootDiskName, err)
-	}
-
-	// Check if this is a dataVolume or a pvc
-	if dataVolumeRaw, ok := rootVolume["dataVolume"]; ok {
-		dataVolume, ok := dataVolumeRaw.(map[string]interface{})
-		if !ok {
-			return nil, fmt.Errorf(
-				"wrong type for vmi dataVolume: expected map[string]interface{}, actual %T", dataVolumeRaw)
+	var rootDiskName, pvcName string
+	for _, rootDiskCandidate := range rootDiskCandidates {
+		rootVolume, err := c.unstructuredFindKeyValString(volumes, "name", rootDiskCandidate)
+		if err != nil {
+			// malformed data
+			return nil, fmt.Errorf("failed to get root disk candidate %q from the volumes section of vmi: %w",
+				rootDiskCandidate, err)
 		}
-		name, found, err := c.unstructuredGetValString(dataVolume, "name")
-		if err != nil || !found {
-			return nil, fmt.Errorf("failed to get name of the rootdisk data volume: %w", err)
+		if rootVolume == nil {
+			continue
 		}
-		// pvc name is always same as the data volume name
-		pvcName = name
-	} else if pvcRaw, ok := rootVolume["persistentVolumeClaim"]; ok {
-		pvc, ok := pvcRaw.(map[string]interface{})
-		if !ok {
-			return nil, fmt.Errorf("wrong type for vmi pvc: expected map[string]interface{}, actual %T", pvcRaw)
+		// Check if this is a dataVolume or a pvc
+		if dataVolumeRaw, ok := rootVolume["dataVolume"]; ok {
+			dataVolume, ok := dataVolumeRaw.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf(
+					"wrong type for vmi dataVolume: expected map[string]interface{}, actual %T", dataVolumeRaw)
+			}
+			name, found, err := c.unstructuredGetValString(dataVolume, "name")
+			if err != nil || !found {
+				return nil, fmt.Errorf(
+					"failed to get dataVolume name for root disk candidate %q: %w", rootDiskCandidate, err)
+			}
+			// pvc name is always same as the data volume name
+			pvcName = name
+		} else if pvcRaw, ok := rootVolume["persistentVolumeClaim"]; ok {
+			pvc, ok := pvcRaw.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("wrong type for vmi pvc: expected map[string]interface{}, actual %T", pvcRaw)
+			}
+			name, found, err := c.unstructuredGetValString(pvc, "claimName")
+			if err != nil || !found {
+				return nil, fmt.Errorf("failed to get PVC name for root disk candidate %q: %w", rootDiskCandidate, err)
+			}
+			pvcName = name
 		}
-		name, found, err := c.unstructuredGetValString(pvc, "claimName")
-		if err != nil || !found {
-			return nil, fmt.Errorf("failed to get name of the rootdisk pvc: %w", err)
+		if pvcName != "" {
+			rootDiskName = rootDiskCandidate
+			break
 		}
-		pvcName = name
-	} else {
-		return nil, fmt.Errorf("root volume is neither a dataVolume nor a pvc")
 	}
 	if pvcName == "" {
-		return nil, fmt.Errorf("empty pvc name for the root disk")
+		return nil, fmt.Errorf("could not find a PVC or a dataVolume among VM disks %v", rootDiskCandidates)
 	}
 
 	// check if the VMI is live migratable and ready


### PR DESCRIPTION
…Order is not present

**What this PR does / why we need it**:

When the boot order was not specified for the VMI disks, we were blindly picking the first disk. Now, we pick the first PVC or a DataVolume disk to avoid failure when the first disk is something like a cloud-init disk.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->


**Which issue(s) this PR fixes** (optional)
PWX-38237

**Special notes for your reviewer**:
Ran the unit test on my OCP cluster on VMs with and without bootorder. 

VMI with bootorder:
```
$ kubectl -n ns1 get vmi fedora-vm-multidisk-wffc -o yaml 
...
    devices:
      disks:
      - bootOrder: 1
        disk:
          bus: virtio
        name: rootdisk
      - bootOrder: 2
        disk:
          bus: virtio
        name: cloudinitdisk
...
```
Test output:
```
Running tool: /usr/local/go1.19/bin/go test -timeout 600s -run ^TestGetVMI$ github.com/portworx/sched-ops/k8s/kubevirt-dynamic -test.v

=== RUN   TestGetVMI
    virtualmachineinstance_test.go:30: VMI: &{fedora-vm-multidisk-wffc ns1 28c79280-8354-4f87-9865-e363815f0476 rootdisk fedora-root-disk true true false pwx-ocp-152-217-gkgm8-worker-0-cdt5v Running [0xc0001e1230 0xc0001e1290 0xc0001e12c0 0xc0001e13b0] 26d48a28-4124-4c2d-8b61-46ce7aff6e6a}
...
--- PASS: TestGetVMI (0.03s)
PASS
ok  	github.com/portworx/sched-ops/k8s/kubevirt-dynamic	0.056s
```

VMI without bootorder and first disk is not PVC or a dataVolume:
```
      disks:
      - disk:
          bus: virtio
        name: cloudinitdisk
      - disk:
          bus: virtio
        name: rootdisk
```
Test ouput:
```
Running tool: /usr/local/go1.19/bin/go test -timeout 600s -run ^TestGetVMI$ github.com/portworx/sched-ops/k8s/kubevirt-dynamic -test.v

=== RUN   TestGetVMI
    virtualmachineinstance_test.go:30: VMI: &{fedora-vm-multidisk-wffc ns2 7d16c50c-b294-43da-a9c7-126a7bccb9c6 rootdisk fedora-root-disk true true false pwx-ocp-152-217-gkgm8-worker-0-tl8mb Running [0xc000694c30 0xc000694c60 0xc000694c90 0xc000694cc0] b2808706-de1c-48f2-a1df-e5835e7e5ce7}
...
--- PASS: TestGetVMI (0.03s)
PASS
ok  	github.com/portworx/sched-ops/k8s/kubevirt-dynamic	(cached)
```