### PR TITLE
PWX-38340: fix race issues when updating k8s configmaps

### DIFF
--- a/k8s/core/configmap/configmap.go
+++ b/k8s/core/configmap/configmap.go
@@ -129,10 +129,12 @@ func (c *configMap) incrementGeneration(cm *corev1.ConfigMap) uint64 {
 	gen, err := strconv.ParseUint(val, 10, 64)
 	if err != nil {
 		logrus.Errorf("Failed to parse generation %s; resetting to 1: %v", val, err)
-		return 1
+		val = "0"
+		gen = 0
 	}
 	newGen := gen + 1
 	if newGen == 0 {
+		logrus.Warnf("Resetting generation to 1 from %s", val)
 		newGen = 1
 	}
 	cm.Data[pxGenerationKey] = strconv.FormatUint(newGen, 10)

--- a/k8s/core/configmap/configmap_lock_v1.go
+++ b/k8s/core/configmap/configmap_lock_v1.go
@@ -127,7 +127,10 @@ func (c *configMap) tryLockV1(id string, refresh bool) (string, error) {
 	currentOwner := cm.Data[pxOwnerKey]
 	if refresh {
 		if currentOwner != id {
-			// we lost our lock probably because we could not refresh it in time
+			// We lost our lock probably because we could not refresh it in time. Note that even if the
+			// lock is available now, it is not safe to just re-acquire the lock here in refresh.
+			// We will fail any subsequent Patch/Delete calls being made under this lock. Caller must start over and
+			// call Lock() again.
 			configMapLog(fn, c.name, "", "", nil).Warnf(
 				"Lost our lock on the configMap %s to a new owner %q", c.name, currentOwner)
 			return "", ErrConfigMapLockLost

--- a/k8s/core/configmap/configmap_lock_v1.go
+++ b/k8s/core/configmap/configmap_lock_v1.go
@@ -1,6 +1,7 @@
 package configmap
 
 import (
+	"errors"
 	"time"
 
 	"github.com/portworx/sched-ops/k8s/core"
@@ -14,6 +15,10 @@ func (c *configMap) Lock(id string) error {
 
 func (c *configMap) LockWithParams(id string, holdTimeout time.Duration, numAttempts uint) error {
 	fn := "LockWithParams"
+
+	// wait for any previous refreshLockV1 goroutine to exit
+	c.kLockV1.wg.Wait()
+
 	if numAttempts == 0 {
 		// This is the same no. of times (300) we try while acquiring a kvdb lock
 		numAttempts = c.lockAttempts
@@ -37,11 +42,18 @@ func (c *configMap) LockWithParams(id string, holdTimeout time.Duration, numAtte
 		configMapLog(fn, c.name, owner, "", err).Warnf("Spent %v iteration"+
 			" locking.", count)
 	}
+	c.kLockV1.Lock()
+	defer c.kLockV1.Unlock()
 	c.lockHoldTimeoutV1 = holdTimeout
 	c.kLockV1.id = id
-
 	c.kLockV1.unlocked = false
-	go c.refreshLockV1(id)
+	c.kLockV1.done = make(chan struct{})
+
+	c.kLockV1.wg.Add(1)
+	go func() {
+		c.refreshLockV1(id)
+		c.kLockV1.wg.Done()
+	}()
 	return nil
 }
 
@@ -56,7 +68,9 @@ func (c *configMap) Unlock() error {
 		return nil
 	}
 	c.kLockV1.unlocked = true
-	c.kLockV1.done <- struct{}{}
+	// Don't write to the chan since the refresh goroutine might have exited already if the lock was lost.
+	// If we write to the chan, we may block indefinitely.
+	close(c.kLockV1.done)
 
 	var (
 		err error
@@ -95,6 +109,7 @@ func (c *configMap) Unlock() error {
 }
 
 func (c *configMap) tryLockV1(id string, refresh bool) (string, error) {
+	fn := "tryLockV1"
 	// Get the existing ConfigMap
 	cm, err := core.Instance().GetConfigMap(
 		c.name,
@@ -110,16 +125,21 @@ func (c *configMap) tryLockV1(id string, refresh bool) (string, error) {
 	}
 
 	currentOwner := cm.Data[pxOwnerKey]
-	if currentOwner != "" {
-		if currentOwner == id && refresh {
-			// We already hold the lock just refresh
-			// our expiry
-			goto increase_expiry
-		} // refresh not requested
-		// Someone might have a lock on the cm
-		// Check expiration
+	if refresh {
+		if currentOwner != id {
+			// we lost our lock probably because we could not refresh it in time
+			configMapLog(fn, c.name, "", "", nil).Warnf(
+				"Lost our lock on the configMap %s to a new owner %q", c.name, currentOwner)
+			return "", ErrConfigMapLockLost
+		}
+		// We already hold the lock just refresh our expiry (fall through)
+	} else if currentOwner != "" {
+		// Someone else might have a lock on the cm. Check expiration.
 		expiration := cm.Data[pxExpirationKey]
-		if expiration != "" {
+		if expiration == "" {
+			configMapLog(fn, c.name, "", "", nil).Warnf(
+				"ConfigMap %v has an owner %s but no expiry; taking the lock away", c.name, currentOwner)
+		} else {
 			expiresAt, err := time.Parse(time.UnixDate, expiration)
 			if err != nil {
 				return currentOwner, err
@@ -131,10 +151,8 @@ func (c *configMap) tryLockV1(id string, refresh bool) (string, error) {
 			} // else lock is expired. Try to lock it.
 		}
 	}
-
 	// Take the lock or increase our expiration if we are already holding the lock
 	cm.Data[pxOwnerKey] = id
-increase_expiry:
 	cm.Data[pxExpirationKey] = time.Now().Add(v1DefaultK8sLockTTL).Format(time.UnixDate)
 	if _, err = core.Instance().UpdateConfigMap(cm); err != nil {
 		return "", err
@@ -143,7 +161,7 @@ increase_expiry:
 }
 
 func (c *configMap) refreshLockV1(id string) {
-	fn := "refreshLock"
+	fn := "refreshLockV1"
 	refresh := time.NewTicker(v1DefaultK8sLockRefreshDuration)
 	var (
 		currentRefresh time.Time
@@ -159,6 +177,7 @@ func (c *configMap) refreshLockV1(id string) {
 			for !c.kLockV1.unlocked {
 				c.checkLockTimeout(c.lockHoldTimeoutV1, startTime, id)
 				currentRefresh = time.Now()
+
 				if _, err := c.tryLockV1(id, true); err != nil {
 					configMapLog(fn, c.name, "", "", err).Errorf(
 						"Error refreshing lock. [Owner %v] [Err: %v]"+
@@ -169,6 +188,19 @@ func (c *configMap) refreshLockV1(id string) {
 						// try refreshing again
 						continue
 					}
+					if errors.Is(err, ErrConfigMapLockLost) {
+						// there is no coming back from this
+						c.kLockV1.unlocked = true
+						c.kLockV1.done = nil
+						c.kLockV1.Unlock()
+						return
+					}
+				}
+				thresh := v1DefaultK8sLockRefreshDuration * 3 / 2
+				if !prevRefresh.IsZero() && prevRefresh.Add(thresh).Before(currentRefresh) {
+					configMapLog(fn, c.name, "", "", nil).Warnf(
+						"V1 lock refresh is taking too long. [Owner %v] [Current Refresh: %v] [Previous Refresh: %v]",
+						id, currentRefresh, prevRefresh)
 				}
 				prevRefresh = currentRefresh
 				break

--- a/k8s/core/configmap/configmap_lock_v1_test.go
+++ b/k8s/core/configmap/configmap_lock_v1_test.go
@@ -230,8 +230,12 @@ func TestDeleteKeyLockedV1(t *testing.T) {
 	require.Contains(t, resultMap, "key1")
 	require.Contains(t, resultMap, "key2")
 
+	err = cm.DeleteKeyLocked(true, "no-such-owner", "key1")
+	require.Error(t, err, "Expected error in DeleteKeyLocked with wrong owner")
+	require.ErrorContains(t, err, "lock check failed")
+
 	err = cm.DeleteKeyLocked(true, "lock-owner", "key1")
-	require.NoError(t, err, "Unexpected error in Patch")
+	require.NoError(t, err, "Unexpected error in DeleteKeyLocked")
 
 	err = cm.Unlock()
 	require.NoError(t, err, "Unexpected error in Unlock")

--- a/k8s/core/configmap/configmap_lock_v2.go
+++ b/k8s/core/configmap/configmap_lock_v2.go
@@ -2,6 +2,7 @@ package configmap
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -20,13 +21,20 @@ func (c *configMap) LockWithKey(owner, key string) error {
 	fn := "LockWithKey"
 	configMapLog(fn, c.name, owner, key, nil).Debugf("Taking the lock")
 
+	c.kLocksV2Mutex.Lock()
+	lock := c.kLocksV2[key]
+	c.kLocksV2Mutex.Unlock()
+	if lock != nil {
+		// wait for any previous refreshLock goroutine to exit
+		lock.wg.Wait()
+	}
 	count := uint(0)
 	// try acquiring a lock on the ConfigMap
-	newOwner, err := c.tryLock(owner, key)
+	newOwner, err := c.tryLock(owner, key, false)
 	// if it fails, keep trying for the provided number of retries until it succeeds
 	for maxCount := c.lockAttempts; err != nil && count < maxCount; count++ {
 		time.Sleep(lockSleepDuration)
-		newOwner, err = c.tryLock(owner, key)
+		newOwner, err = c.tryLock(owner, key, false)
 		if count > 0 && count%15 == 0 && err != nil {
 			configMapLog(fn, c.name, newOwner, key, err).Warnf("Locked for"+
 				" %v seconds", float64(count)*lockSleepDuration.Seconds())
@@ -41,16 +49,17 @@ func (c *configMap) LockWithKey(owner, key string) error {
 			" locking.", count)
 	}
 
+	lock = &k8sLock{done: make(chan struct{}), id: owner}
 	c.kLocksV2Mutex.Lock()
-	if _, ok := c.kLocksV2[key]; ok {
-		c.kLocksV2Mutex.Unlock()
-		return nil
-	}
-	c.kLocksV2[key] = &k8sLock{done: make(chan struct{}), id: owner}
+	c.kLocksV2[key] = lock
 	c.kLocksV2Mutex.Unlock()
 
 	configMapLog(fn, c.name, owner, key, nil).Debugf("Starting lock refresh")
-	go c.refreshLock(owner, key)
+	lock.wg.Add(1)
+	go func() {
+		c.refreshLock(owner, key)
+		lock.wg.Done()
+	}()
 	return nil
 }
 
@@ -78,7 +87,9 @@ func (c *configMap) UnlockWithKey(key string) error {
 		return nil
 	}
 	lock.unlocked = true
-	lock.done <- struct{}{}
+	// Don't write to the chan since the refresh goroutine might have exited already if the lock was lost.
+	// If we write to the chan, we may block indefinitely.
+	close(lock.done)
 
 	var (
 		err error
@@ -170,7 +181,7 @@ func (c *configMap) IsKeyLocked(key string) (bool, string, error) {
 	return false, "", nil
 }
 
-func (c *configMap) tryLock(owner string, key string) (string, error) {
+func (c *configMap) tryLock(owner string, key string, refresh bool) (string, error) {
 	// Get the existing ConfigMap
 	cm, err := core.Instance().GetConfigMap(
 		c.name,
@@ -190,7 +201,7 @@ func (c *configMap) tryLock(owner string, key string) (string, error) {
 		return "", fmt.Errorf("failed to get locks from configmap: %v", err)
 	}
 
-	finalOwner, err := c.checkAndTakeLock(owner, key, lockIDs, lockExpirations)
+	finalOwner, err := c.checkAndTakeLock(owner, key, refresh, lockIDs, lockExpirations)
 	if err != nil {
 		return finalOwner, err
 	}
@@ -204,6 +215,15 @@ func (c *configMap) tryLock(owner string, key string) (string, error) {
 		return "", err
 	}
 	return owner, nil
+}
+
+// Returns the lock owner for the v2 lock regardless of whether the lock has expired.
+func (c *configMap) getV2LockOwnerIncludeExpired(cm *v1.ConfigMap, key string) (string, error) {
+	lockOwners, _, err := c.parseLocks(cm)
+	if err != nil {
+		return "", err
+	}
+	return lockOwners[key], nil
 }
 
 // parseLocks reads the lock data from the given ConfigMap and then converts it to:
@@ -231,15 +251,18 @@ func (c *configMap) parseLocks(cm *v1.ConfigMap) (map[string]string, map[string]
 	return lockOwners, lockExpirations, nil
 }
 
-// checkAndTakeLock tries to take the given lock (owner, key) given the current state of the lock
-// (lockOwners, lockExpirations).
+// checkAndTakeLock checks if we can take the desired lock (refresh=false) or extend the expiration of the lock
+// we have taken already (refresh=true). If either condition is true, it updates the in-memory state in
+// lockOwners and lockExpirations. "refresh" argument indicates if this is the refreshLock goroutine refreshing
+// the lock or an initial Lock call taking the lock.
 func (c *configMap) checkAndTakeLock(
 	owner, key string,
+	refresh bool,
 	lockOwners map[string]string,
 	lockExpirations map[string]time.Time,
 ) (string, error) {
 	fn := "checkAndTakeLock"
-	_, ownerOK := lockOwners[key]
+	currentOwner, ownerOK := lockOwners[key]
 	_, expOK := lockExpirations[key]
 
 	// Just check to make sure these are consistent and that we either have both or don't
@@ -248,30 +271,31 @@ func (c *configMap) checkAndTakeLock(
 	}
 	k8sTTL := c.lockK8sLockTTL
 
-	// Now that we've parsed all the lock lines, let's check the specific key we're taking
-	if !ownerOK {
-		// There is no lock, we can take it
+	if refresh {
+		if currentOwner != owner {
+			// Our lock was revoked by someone else probably because we could not refresh it in time.
+			configMapLog(fn, c.name, "", "", nil).Warnf(
+				"Lost our lock on key %s in the configMap %s to a new owner %q", key, c.name, currentOwner)
+			return currentOwner, ErrConfigMapLockLost
+		}
+		// We hold the lock; just refresh the expiry
+		lockExpirations[key] = time.Now().Add(k8sTTL)
+		return owner, nil
+	}
+
+	if currentOwner == "" {
 		lockOwners[key] = owner
 		lockExpirations[key] = time.Now().Add(k8sTTL)
 		return owner, nil
 	}
 
-	// There is a lock: let's check it out and see what the details are
-
-	// If we hold the lock, just refresh it
-	if lockOwners[key] == owner {
-		lockExpirations[key] = time.Now().Add(k8sTTL)
-		return owner, nil
-	}
-
-	// Now let's see if the lock is expired or not: if it's not expired, we can't take it
 	if time.Now().Before(lockExpirations[key]) {
 		return lockOwners[key], ErrConfigMapLocked
 	}
 
-	configMapLog(fn, c.name, owner, key, nil).Infof("Lock from owner '%s' is expired, now claiming for new owner '%s'", lockOwners[key], owner)
+	configMapLog(fn, c.name, owner, key, nil).Infof(
+		"Lock from owner '%s' is expired, now claiming for new owner '%s'", currentOwner, owner)
 
-	// Lock is expired: let's take it
 	lockOwners[key] = owner
 	lockExpirations[key] = time.Now().Add(k8sTTL)
 	return owner, nil
@@ -311,6 +335,7 @@ func (c *configMap) updateConfigMap(cm *v1.ConfigMap) (bool, error) {
 func (c *configMap) refreshLock(id, key string) {
 	fn := "refreshLock"
 	refresh := time.NewTicker(c.lockRefreshDuration)
+	defer refresh.Stop()
 	var (
 		currentRefresh time.Time
 		prevRefresh    time.Time
@@ -324,8 +349,11 @@ func (c *configMap) refreshLock(id, key string) {
 	lock := c.kLocksV2[key]
 	c.kLocksV2Mutex.Unlock()
 
+	if lock == nil {
+		return
+	}
+
 	startTime = time.Now()
-	defer refresh.Stop()
 	for {
 		select {
 		case <-refresh.C:
@@ -334,7 +362,7 @@ func (c *configMap) refreshLock(id, key string) {
 			for !lock.unlocked {
 				c.checkLockTimeout(c.defaultLockHoldTimeout, startTime, id)
 				currentRefresh = time.Now()
-				if _, err := c.tryLock(id, key); err != nil {
+				if _, err := c.tryLock(id, key, true); err != nil {
 					configMapLog(fn, c.name, "", key, err).Errorf(
 						"Error refreshing lock. [ID %v] [Key %v] [Err: %v]"+
 							" [Current Refresh: %v] [Previous Refresh: %v]",
@@ -344,6 +372,18 @@ func (c *configMap) refreshLock(id, key string) {
 						// try refreshing again
 						continue
 					}
+					if errors.Is(err, ErrConfigMapLockLost) {
+						// there is no coming back from this
+						lock.unlocked = true
+						lock.Unlock()
+						return
+					}
+				}
+				thresh := c.lockRefreshDuration * 3 / 2
+				if !prevRefresh.IsZero() && prevRefresh.Add(thresh).Before(currentRefresh) {
+					configMapLog(fn, c.name, "", "", nil).Warnf(
+						"V2 lock refresh is taking too long. [Owner %v] [Current Refresh: %v] [Previous Refresh: %v]",
+						id, currentRefresh, prevRefresh)
 				}
 				prevRefresh = currentRefresh
 				break

--- a/k8s/core/configmap/configmap_lock_v2_test.go
+++ b/k8s/core/configmap/configmap_lock_v2_test.go
@@ -11,14 +11,16 @@ import (
 )
 
 const (
-	lockTimeout = 15 * time.Second
+	testLockTimeout         = 5 * time.Second
+	testLockAttempts        = 3
+	testLockRefreshDuration = 1 * time.Second
+	testLockTTL             = 3 * time.Second
 )
 
 func TestMultilock(t *testing.T) {
-	t.Skip("skipped until PWX-31627 is fixed")
 	fakeClient := fakek8sclient.NewSimpleClientset()
 	coreops.SetInstance(coreops.New(fakeClient))
-	cm, err := New("px-configmaps-test", nil, lockTimeout, 3, 0, 0)
+	cm, err := New("px-configmaps-test", nil, testLockTimeout, testLockAttempts, testLockRefreshDuration, testLockTTL)
 	require.NoError(t, err, "Unexpected error on New")
 
 	fmt.Println("testMultilock")
@@ -32,8 +34,10 @@ func TestMultilock(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, locked)
 
+	fmt.Println("\tlocking key 1")
 	err = cm.LockWithKey(id1, key1)
 	require.NoError(t, err, "Unexpected error in LockWithKey(id1,key1)")
+	fmt.Println("\tlocked ID 1 key 1")
 
 	locked, owner, err := cm.IsKeyLocked(key1)
 	require.NoError(t, err)
@@ -43,6 +47,7 @@ func TestMultilock(t *testing.T) {
 	fmt.Println("\tlocking key 2")
 	err = cm.LockWithKey(id2, key2)
 	require.NoError(t, err, "Unexpected error in LockWithKey(id2,key2)")
+	fmt.Println("\tlocked ID 2 key 2")
 
 	locked, owner, err = cm.IsKeyLocked(key2)
 	require.NoError(t, err)
@@ -52,16 +57,18 @@ func TestMultilock(t *testing.T) {
 	fmt.Println("\tunlocking key 1")
 	err = cm.UnlockWithKey(key1)
 	require.NoError(t, err, "Unexpected error in UnlockWithKey(id1,key1)")
+	fmt.Println("\tunlocked ID 1 key 1")
 
-	locked, owner, err = cm.IsKeyLocked(key1)
+	locked, _, err = cm.IsKeyLocked(key1)
 	require.NoError(t, err)
 	require.False(t, locked)
 
 	fmt.Println("\tunlocking key 2")
 	err = cm.UnlockWithKey(key2)
 	require.NoError(t, err, "Unexpected error in UnlockWithKey(id1,key1)")
+	fmt.Println("\tunlocked ID 2 key 2")
 
-	locked, owner, err = cm.IsKeyLocked(key2)
+	locked, _, err = cm.IsKeyLocked(key2)
 	require.NoError(t, err)
 	require.False(t, locked)
 
@@ -69,72 +76,231 @@ func TestMultilock(t *testing.T) {
 	fmt.Println("\tlocking ID 1 key 1")
 	err = cm.LockWithKey(id1, key1)
 	require.NoError(t, err, "Unexpected error in LockWithKey(id1,key1)")
+	fmt.Println("\tlocked ID 1 key 1")
 
 	go func() {
 		time.Sleep(1 * time.Second)
 		// Second lock below will block until this unlock (because of same ID)
-		fmt.Println("\tunlocking key 1")
+		fmt.Println("\tunlocking ID 1 key 1")
 		err := cm.UnlockWithKey(key1)
 		require.NoError(t, err, "Unexpected error from UnlockWithKey(key1)")
+		fmt.Println("\tunlocked ID 1 key 1")
 	}()
 	fmt.Println("\tlocking ID 1 key 2")
 	err = cm.LockWithKey(id1, key2)
 	require.NoError(t, err, "Unexpected error in LockWithKey(id1,key2)")
+	fmt.Println("\tlocked ID 1 key 2")
 
 	fmt.Println("\tunlocking key 2")
 	err = cm.UnlockWithKey(key2)
 	require.NoError(t, err, "Unexpected error in UnlockWithKey(key2)")
+	fmt.Println("\tunlocked key 2")
 
 	fmt.Println("\tdouble lock with same key")
 	fmt.Println("\tlocking ID 1 key 1")
 	err = cm.LockWithKey(id1, key1)
 	require.NoError(t, err, "Unexpected error in LockWithKey(id1,key1)")
+	fmt.Println("\tlocked ID 1 key 1")
 
 	go func() {
 		time.Sleep(1 * time.Second)
 		// Second lock below will block until this unlock (because of same key)
-		fmt.Println("\tunlocking key 1")
+		fmt.Println("\tunlocking ID 1 key 1")
 		err := cm.UnlockWithKey(key1)
 		require.NoError(t, err, "Unexpected error from UnlockWithKey(key1)")
+		fmt.Println("\tunlocked ID 1 key 1")
 	}()
 	fmt.Println("\tlocking ID 2 key 1")
 	err = cm.LockWithKey(id2, key1)
 	require.NoError(t, err, "Unexpected error in LockWithKey(id2,key1)")
+	fmt.Println("\tlocked ID 2 key 1")
 
 	fmt.Println("\tunlocking key 1")
 	err = cm.UnlockWithKey(key1)
 	require.NoError(t, err, "Unexpected error in UnlockWithKey(key1)")
+	fmt.Println("\tunlocked ID 2 key 1")
 
-	fmt.Println("\tlockExpiration")
+	// all keys should be unlocked now
+	locked, _, err = cm.IsKeyLocked(key1)
+	require.NoError(t, err)
+	require.False(t, locked)
+
+	locked, _, err = cm.IsKeyLocked(key2)
+	require.NoError(t, err)
+	require.False(t, locked)
+
+	err = cm.Delete()
+	require.NoError(t, err, "Unexpected error on Delete")
+}
+
+func TestExpiration(t *testing.T) {
+	fakeClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(fakeClient))
+	cm, err := New("px-configmaps-test", nil, testLockTimeout, testLockAttempts, testLockRefreshDuration, testLockTTL)
+	require.NoError(t, err, "Unexpected error on New")
+
+	fmt.Println("TestExpiration")
+
+	id1 := "id1"
+	id2 := "id2"
+	key1 := "key1"
 
 	var lockTimedout bool
 	fatalLockCb := func(format string, args ...interface{}) {
 		fmt.Println("\tLock timeout called.")
 		lockTimedout = true
+		// since our fatalCb does not panic, we need to unlock to stop the lock from refreshing
+		go func() {
+			fmt.Println("\tunlocking key 1 from fatalCb")
+			cm.UnlockWithKey(key1)
+			fmt.Println("\tunlocked key 1 from fatalCb")
+		}()
 	}
 	SetFatalCb(fatalLockCb)
 
 	// Check lock expiration
+	fmt.Println("\tlocking ID 1 key 1")
 	err = cm.LockWithKey(id1, key1)
 	require.NoError(t, err, "Unexpected error in lock")
+	fmt.Println("\tlocked ID 1 key 1")
 
-	// Locking again with same owner should not throw error
-	err = cm.LockWithKey(id1, key1)
-	require.NoError(t, err, "Unexpected error in lock")
-	time.Sleep((v2DefaultK8sLockRefreshDuration * 3) + (3 * time.Second))
+	// Wait for lock hold timeout which will stop the refresh
+	time.Sleep(testLockTimeout + time.Second)
 	require.True(t, lockTimedout, "Lock hold timeout not triggered")
+
+	// Wait for lock to expire
+	time.Sleep(testLockTTL + 100*time.Millisecond)
 
 	// Locking again with expired lock should not throw error
 	err = cm.LockWithKey(id1, key1)
 	require.NoError(t, err, "Unexpected error in lock")
 
 	err = cm.UnlockWithKey(key1)
-	require.NoError(t, err, "Unexpected no error in unlock")
+	require.NoError(t, err, "Unexpected error in unlock")
 
 	err = cm.LockWithKey(id2, key1)
-	require.NoError(t, err, "Lock should have expired")
+	require.NoError(t, err, "Unexpected error in lock")
 	err = cm.UnlockWithKey(key1)
-	require.NoError(t, err, "Unexpected no error in unlock")
+	require.NoError(t, err, "Unexpected error in unlock")
 	err = cm.Delete()
 	require.NoError(t, err, "Unexpected error on Delete")
+}
+
+func TestCMLockLostV2(t *testing.T) {
+	fakeClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(fakeClient))
+	cmIntf, err := New("px-configmaps-test", nil, testLockTimeout, testLockAttempts, testLockRefreshDuration, testLockTTL)
+	require.NoError(t, err, "Unexpected error on New")
+
+	cm := cmIntf.(*configMap)
+
+	id1 := "id1"
+	key1 := "key1"
+
+	err = cm.LockWithKey(id1, key1)
+	require.NoError(t, err, "Unexpected error in LockWithKey(id1,key1)")
+
+	err = cm.PatchKeyLocked(false, id1, key1, "val1")
+	require.NoError(t, err, "Unexpected error in Patch")
+
+	// case: lock lost with NO new owner
+	setV2LockOwnerForTesting(t, cm, key1, "", time.Time{})
+	err = cm.PatchKeyLocked(false, id1, key1, "val2")
+	require.Error(t, err, "Expected error in Patch")
+	require.ErrorContains(t, err, "lock check failed")
+
+	// case: re-take the lock and update
+	err = cm.LockWithKey(id1, key1)
+	require.NoError(t, err, "Unexpected error in LockWithKey(id1,key1)")
+
+	err = cm.PatchKeyLocked(false, id1, key1, "val1")
+	require.NoError(t, err, "Unexpected error in Patch")
+
+	// case: lock lost to a new owner
+	setV2LockOwnerForTesting(t, cm, key1, "new-owner", time.Now().Add(5*time.Minute))
+	err = cm.PatchKeyLocked(false, id1, key1, "val2")
+	require.Error(t, err, "Expected error in Patch")
+	require.ErrorContains(t, err, "lock check failed")
+
+	// case: re-taking the lock should fail with "configmap is locked" error
+	err = cm.LockWithKey(id1, key1)
+	require.Error(t, err, "Expected error in Patch")
+	require.ErrorContains(t, err, "ConfigMap is locked")
+
+	// case: new owner releases the lock; then we should be able to take the lock
+	setV2LockOwnerForTesting(t, cm, key1, "", time.Time{})
+	err = cm.LockWithKey(id1, key1)
+	require.NoError(t, err, "Unexpected error in LockWithKey(id1,key1)")
+
+	err = cm.PatchKeyLocked(false, id1, key1, "val3")
+	require.NoError(t, err, "Unexpected error in Patch")
+
+	err = cm.UnlockWithKey(key1)
+	require.NoError(t, err, "Unexpected error in UnlockWithKey(key1)")
+
+	resultMap, err := cm.Get()
+	require.NoError(t, err, "Unexpected error in Get")
+	require.Contains(t, resultMap, key1)
+	require.Equal(t, "val3", resultMap[key1])
+}
+
+func TestDeleteKeyLockedV2(t *testing.T) {
+	fakeClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(fakeClient))
+	cmIntf, err := New("px-configmaps-test", nil, testLockTimeout, testLockAttempts, testLockRefreshDuration, testLockTTL)
+	require.NoError(t, err, "Unexpected error on New")
+
+	cm := cmIntf.(*configMap)
+
+	id1 := "id1"
+	key1 := "key1"
+
+	err = cm.LockWithKey(id1, key1)
+	require.NoError(t, err, "Unexpected error in LockWithKey(id1,key1)")
+
+	err = cm.PatchKeyLocked(false, id1, key1, "val1")
+	require.NoError(t, err, "Unexpected error in Patch")
+
+	resultMap, err := cm.Get()
+	require.NoError(t, err, "Unexpected error in Get")
+	require.Contains(t, resultMap, key1)
+	require.Equal(t, "val1", resultMap[key1])
+
+	err = cm.DeleteKeyLocked(false, id1, key1)
+	require.NoError(t, err, "Unexpected error in DeleteKeyLocked")
+
+	err = cm.UnlockWithKey(key1)
+	require.NoError(t, err, "Unexpected error in UnlockWithKey(key1)")
+
+	resultMap, err = cm.Get()
+	require.NoError(t, err, "Unexpected error in Get")
+	require.NotContains(t, resultMap, key1)
+
+}
+
+func setV2LockOwnerForTesting(t *testing.T, cm *configMap, key, owner string, expiration time.Time) {
+	require.Eventually(t, func() bool {
+		rawCM, err := coreops.Instance().GetConfigMap(cm.name, k8sSystemNamespace)
+		if err != nil {
+			return false
+		}
+		lockOwners, lockExpirations, err := cm.parseLocks(rawCM)
+		if err != nil {
+			return false
+		}
+		if owner == "" {
+			delete(lockOwners, key)
+			delete(lockExpirations, key)
+		} else {
+			lockOwners[key] = owner
+			lockExpirations[key] = expiration
+		}
+
+		err = cm.generateConfigMapData(rawCM, lockOwners, lockExpirations)
+		if err != nil {
+			return false
+		}
+		_, err = coreops.Instance().UpdateConfigMap(rawCM)
+		return err == nil
+	}, 5*time.Second, 100*time.Millisecond)
 }

--- a/k8s/core/configmap/configmap_test.go
+++ b/k8s/core/configmap/configmap_test.go
@@ -17,7 +17,7 @@ func TestGetConfigMap(t *testing.T) {
 	configData := map[string]string{
 		"key1": "val1",
 	}
-	cm, err := New("px-configmaps-test", configData, lockTimeout, 5, 0, 0)
+	cm, err := New("px-configmaps-test", configData, testLockTimeout, 5, 0, 0)
 	require.NoError(t, err, "Unexpected error in creating configmap")
 
 	resultMap, err := cm.Get()
@@ -34,56 +34,10 @@ func TestDeleteConfigMap(t *testing.T) {
 		"key1": "val1",
 	}
 
-	cm, err := New("px-configmaps-test", configData, lockTimeout, 5, 0, 0)
+	cm, err := New("px-configmaps-test", configData, testLockTimeout, 5, 0, 0)
 	require.NoError(t, err, "Unexpected error in creating configmap")
 
 	err = cm.Delete()
 	require.NoError(t, err, "Unexpected error in delete")
 
-}
-
-func TestPatchConfigMap(t *testing.T) {
-	fakeClient := fakek8sclient.NewSimpleClientset()
-	coreops.SetInstance(coreops.New(fakeClient))
-
-	configData := map[string]string{
-		"key1": "val1",
-	}
-
-	cm, err := New("px-configmaps-test", configData, lockTimeout, 5, 0, 0)
-	require.NoError(t, err, "Unexpected error in creating configmap")
-
-	dummyData := map[string]string{
-		"key2": "val2",
-	}
-
-	err = cm.Patch(dummyData)
-	require.NoError(t, err, "Unexpected error in Patch")
-	resultMap, err := cm.Get()
-	require.Contains(t, resultMap, "key1")
-	require.Contains(t, resultMap, "key2")
-	fmt.Println(resultMap)
-}
-
-func TestUpdateConfigMap(t *testing.T) {
-	fakeClient := fakek8sclient.NewSimpleClientset()
-	coreops.SetInstance(coreops.New(fakeClient))
-
-	configData := map[string]string{
-		"key1": "val1",
-	}
-
-	cm, err := New("px-configmaps-test", configData, lockTimeout, 5, 0, 0)
-	require.NoError(t, err, "Unexpected error in creating configmap")
-
-	dummyData := map[string]string{
-		"key2": "val2",
-	}
-
-	err = cm.Update(dummyData)
-	require.NoError(t, err, "Unexpected error in Update")
-	resultMap, err := cm.Get()
-	require.NotContains(t, resultMap, "key1")
-	require.Contains(t, resultMap, "key2")
-	fmt.Println(resultMap)
 }

--- a/k8s/core/configmap/types.go
+++ b/k8s/core/configmap/types.go
@@ -41,7 +41,7 @@ const (
 	// objects.
 	pxLockKey = "px-lock"
 
-	// pxGenerationKey is the key which stores the generation of the configmap data. The value is incremented every time
+	// pxGenerationKey stores the generation of the configmap data. The value is incremented every time
 	// the configmap data is updated via PatchKeyLocked or DeleteKeyLocked. This is used for diagnostics purposes only.
 	pxGenerationKey = "px-generation"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Problems that this patch tries to fix:
1. Some callers updated the keys that they had not locked because they specified all keys to Patch()
2. Update() was dangerous because it could overwrite the internal keys used to store locks
3. RefreshLock() could lose the lock and re-acquire it siliently thereby overwriting the intervening update made by someone else
4. Patch could update the configmap while RefreshLock() has lost the ownership of the lock
5. V2 locks were re-entrant but did not keep the reference count causing premature unlocking

Changes:
1. Get rid of the configmap Update() method since it is too dangerous
2. Refactor Patch() into PatchKeyLocked() that updates a single key after verifying lock owner
3. RefreshLock detects loss of lock ownership
4. Add DeleteKeyLocked() method so that a key can be deleted safely
5. Add a generation number to the configmap and log each time the generation is incremented
6. Make v2 locks non-reentrant (like v1 locks) and fix one caller that was expecting the lock to be re-entrant

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**Which issue(s) this PR fixes** (optional)
PWX-38340

**Special notes for your reviewer**:
The production code changes are being reviewed via another PR. Mainly review the unit tests here.

