### PR TITLE
PWX-38340: don't wait for the old refreshLock goroutine to exit

### DIFF
--- a/k8s/core/configmap/configmap_lock_v1_test.go
+++ b/k8s/core/configmap/configmap_lock_v1_test.go
@@ -4,18 +4,17 @@ import (
 	"fmt"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	coreops "github.com/portworx/sched-ops/k8s/core"
 	"github.com/stretchr/testify/require"
-	fakek8sclient "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestLock(t *testing.T) {
-	fakeClient := fakek8sclient.NewSimpleClientset()
-	coreops.SetInstance(coreops.New(fakeClient))
-	cm, err := New("px-configmaps-test", nil, testLockTimeout, 5, 0, 0)
+	setUpConfigMapTestCluster(t)
+	cm, err := New("px-configmaps-lock-test", nil, testLockTimeout, 5, 0, 0)
 	require.NoError(t, err, "Unexpected error on New")
 	fmt.Println("testLock")
 
@@ -112,9 +111,8 @@ func TestLock(t *testing.T) {
 func TestLockWithHoldTimeout(t *testing.T) {
 	defaultHoldTimeout := 3 * time.Second
 	customHoldTimeout := defaultHoldTimeout + v1DefaultK8sLockRefreshDuration + 10*time.Second
-	fakeClient := fakek8sclient.NewSimpleClientset()
-	coreops.SetInstance(coreops.New(fakeClient))
-	cm, err := New("px-configmaps-test", nil, defaultHoldTimeout, 5, 0, 0)
+	setUpConfigMapTestCluster(t)
+	cm, err := New("px-configmaps-lock-hold-test", nil, defaultHoldTimeout, 5, 0, 0)
 	require.NoError(t, err, "Unexpected error on New")
 	fmt.Println("TestLockWithHoldTimeout")
 
@@ -145,14 +143,13 @@ func TestLockWithHoldTimeout(t *testing.T) {
 }
 
 func TestPatchKeyLockedV1(t *testing.T) {
-	fakeClient := fakek8sclient.NewSimpleClientset()
-	coreops.SetInstance(coreops.New(fakeClient))
+	setUpConfigMapTestCluster(t)
 
 	configData := map[string]string{
 		"key1": "val1",
 	}
 
-	cm, err := New("px-configmaps-test", configData, testLockTimeout, 5, 0, 0)
+	cm, err := New("px-configmaps-patch-key-v1-test", configData, testLockTimeout, 5, 0, 0)
 	require.NoError(t, err, "Unexpected error in creating configmap")
 
 	// case: empty lock owner while CM is not locked
@@ -211,14 +208,13 @@ func TestPatchKeyLockedV1(t *testing.T) {
 }
 
 func TestDeleteKeyLockedV1(t *testing.T) {
-	fakeClient := fakek8sclient.NewSimpleClientset()
-	coreops.SetInstance(coreops.New(fakeClient))
+	setUpConfigMapTestCluster(t)
 
 	configData := map[string]string{
 		"key1": "val1",
 	}
 
-	cm, err := New("px-configmaps-test", configData, testLockTimeout, 5, 0, 0)
+	cm, err := New("px-configmaps-delete-v1-test", configData, testLockTimeout, 5, 0, 0)
 	require.NoError(t, err, "Unexpected error in creating configmap")
 
 	err = cm.Lock("lock-owner")
@@ -250,9 +246,8 @@ func TestDeleteKeyLockedV1(t *testing.T) {
 }
 
 func TestCMLockRefreshV1(t *testing.T) {
-	fakeClient := fakek8sclient.NewSimpleClientset()
-	coreops.SetInstance(coreops.New(fakeClient))
-	cmIntf, err := New("px-configmaps-test", nil, 5*time.Minute, 1000, 0, 0)
+	setUpConfigMapTestCluster(t)
+	cmIntf, err := New("px-configmaps-v1-refresh-test", nil, 5*time.Minute, 1000, 0, 0)
 	require.NoError(t, err, "Unexpected error on New")
 
 	cm := cmIntf.(*configMap)
@@ -266,7 +261,7 @@ func TestCMLockRefreshV1(t *testing.T) {
 	err = cm.PatchKeyLocked(true, id1, key1, "val1")
 	require.NoError(t, err, "Unexpected error in Patch")
 
-	time.Sleep(v1DefaultK8sLockRefreshDuration + time.Second)
+	time.Sleep(time.Duration(rand.Intn(int(15 * time.Second))))
 
 	err = cm.PatchKeyLocked(true, id1, key1, "val2")
 	require.NoError(t, err, "Unexpected error in Patch")
@@ -280,22 +275,37 @@ func TestCMLockRefreshV1(t *testing.T) {
 	require.Contains(t, resultMap, key1)
 	require.Equal(t, "val2", resultMap[key1])
 
+	var reentrantCheck atomic.Bool
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 5; i++ {
 		wg.Add(1)
-		go func() {
+		go func(i int) {
 			defer wg.Done()
 
 			err = cm.Lock(id1)
 			require.NoError(t, err, "Unexpected error in Lock(id1)")
 
+			require.True(t, reentrantCheck.CompareAndSwap(false, true), "Reentrant lock detected")
+
+			val := fmt.Sprintf("val%d", i)
+			err = cm.PatchKeyLocked(true, id1, key1, val)
+			require.NoError(t, err, "Unexpected error in Patch")
+
 			// give some time for the refreshLock goroutine to start
 			// v1 lock uses a fixed refresh interval of 8 seconds and expiration of 16 seconds
-			time.Sleep(time.Duration(rand.Intn(17000)) * time.Millisecond)
+			time.Sleep(time.Duration(rand.Intn(int(15 * time.Second))))
+
+			resultMap, err := cm.Get()
+			require.NoError(t, err, "Unexpected error in Get")
+			t.Log(resultMap)
+			require.Contains(t, resultMap, key1)
+			require.Equal(t, val, resultMap[key1])
+
+			require.True(t, reentrantCheck.CompareAndSwap(true, false), "Reentrant lock detected")
 
 			err = cm.Unlock()
 			require.NoError(t, err, "Unexpected error in Unlock(key1)")
-		}()
+		}(i)
 	}
 	wg.Wait()
 
@@ -304,14 +314,13 @@ func TestCMLockRefreshV1(t *testing.T) {
 }
 
 func TestCMLockLostV1(t *testing.T) {
-	fakeClient := fakek8sclient.NewSimpleClientset()
-	coreops.SetInstance(coreops.New(fakeClient))
+	setUpConfigMapTestCluster(t)
 
 	configData := map[string]string{
 		"key1": "val1",
 	}
-
-	cm, err := New("px-configmaps-test", configData, 0, 0, 0, 0)
+	cmName := "px-configmaps-v1-lock-lost-test"
+	cm, err := New(cmName, configData, 0, 0, 0, 0)
 	require.NoError(t, err, "Unexpected error in creating configmap")
 
 	err = cm.Lock("lock-owner")
@@ -321,7 +330,7 @@ func TestCMLockLostV1(t *testing.T) {
 	require.NoError(t, err, "Unexpected error in Patch")
 
 	// case: lock lost with NO new owner
-	setV1LockOwnerForTesting(t, "px-configmaps-test", "", time.Time{})
+	setV1LockOwnerForTesting(t, cmName, "", time.Time{})
 	err = cm.PatchKeyLocked(true, "lock-owner", "key1", "val3")
 	require.Error(t, err, "Expected error in Patch")
 	require.ErrorContains(t, err, "lock check failed")
@@ -334,7 +343,7 @@ func TestCMLockLostV1(t *testing.T) {
 	require.NoError(t, err, "Unexpected error in Patch")
 
 	// case: lock lost to a new owner
-	setV1LockOwnerForTesting(t, "px-configmaps-test", "new-owner", time.Now().Add(5*time.Minute))
+	setV1LockOwnerForTesting(t, cmName, "new-owner", time.Now().Add(5*time.Minute))
 	err = cm.PatchKeyLocked(true, "lock-owner", "key2", "val2")
 	require.Error(t, err, "Expected error in Patch")
 	require.ErrorContains(t, err, "lock check failed")
@@ -345,7 +354,7 @@ func TestCMLockLostV1(t *testing.T) {
 	require.ErrorContains(t, err, "ConfigMap is locked")
 
 	// case: new owner releases the lock; then we should be able to take the lock
-	setV1LockOwnerForTesting(t, "px-configmaps-test", "", time.Time{})
+	setV1LockOwnerForTesting(t, cmName, "", time.Time{})
 	err = cm.Lock("lock-owner")
 	require.NoError(t, err, "Unexpected error in Lock")
 

--- a/k8s/core/configmap/types.go
+++ b/k8s/core/configmap/types.go
@@ -79,10 +79,10 @@ type configMap struct {
 }
 
 type k8sLock struct {
-	wg       sync.WaitGroup
-	done     chan struct{}
-	unlocked bool
-	id       string
+	v1LockGen uint64
+	done      chan struct{}
+	unlocked  bool
+	id        string
 	sync.Mutex
 }
 


### PR DESCRIPTION


<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Instead, the old refreshLock goroutine will detect that the lock has been re-acquired and will exit automatically.

**Which issue(s) this PR fixes** (optional)
PWX-38340

**Special notes for your reviewer**: