### PR TITLE
PWX-38936 Don't return error if try to lock self-locked key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.19.1
+  - 1.22.1
 install:
   - make fetch-tools
   - make vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
+sudo: required
 language: go
 go:
-  - 1.22.1
+  - "1.21.1"
+before_install:
+  - echo $PATH
+  - which go
+  - ls -al $(which go)
+  - sudo find / -name go
 install:
+  - ls -al $(which go)
+  - $(which go) version
   - make fetch-tools
   - make vendor
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: bionic
 language: go
 go:
-  - "1.21.1"
+  - "1.22.6"
 before_install:
   - echo $PATH
   - which go

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: bionic
 language: go
 go:
   - "1.21.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: bionic
 language: go
 go:
-  - "1.22.6"
+  - "1.21.1"
 before_install:
   - echo $PATH
   - which go

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ endif
 
 fetch-tools:
 	mkdir -p tools
-	(cd tools && GO111MODULE=off $(GO) get -u golang.org/x/lint/golint)
-	(cd tools && GO111MODULE=off $(GO) get -v github.com/kisielk/errcheck)
-	(cd tools && GO111MODULE=off $(GO) get -u github.com/vbatts/git-validation)
+	(cd tools && $(GO) install golang.org/x/lint/golint@v0.0.0-20210508222113-6edffad5e616)
+	(cd tools && $(GO) install github.com/kisielk/errcheck@v1.7.0)
+	(cd tools && $(GO) install github.com/vbatts/git-validation@v1.2.0)
 
 # Deliverables
 

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ endif
 
 fetch-tools:
 	mkdir -p tools
-	(cd tools && $(GO) install golang.org/x/lint/golint@v0.0.0-20210508222113-6edffad5e616)
-	(cd tools && $(GO) install github.com/kisielk/errcheck@v1.7.0)
-	(cd tools && $(GO) install github.com/vbatts/git-validation@v1.2.0)
+	(cd tools && $(GO) install -mod=readonly golang.org/x/lint/golint@v0.0.0-20210508222113-6edffad5e616)
+	(cd tools && $(GO) install -mod=readonly github.com/kisielk/errcheck@v1.7.0)
+	(cd tools && $(GO) install -mod=readonly github.com/vbatts/git-validation@v1.2.0)
 
 # Deliverables
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/portworx/sched-ops
 
-go 1.22.6
+go 1.22.3
 toolchain go1.22.6
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/portworx/sched-ops
 
-go 1.22.3
+go 1.22.6
 toolchain go1.22.6
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/portworx/sched-ops
 
-go 1.19
+go 1.22.6
+toolchain go1.22.6
 
 require (
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc7

--- a/k8s/core/configmap/configmap_lock_v2.go
+++ b/k8s/core/configmap/configmap_lock_v2.go
@@ -186,6 +186,8 @@ func (c *configMap) IsKeyLocked(key, requester string) (bool, string, error) {
 		c.kLocksV2Mutex.Lock()
 		defer c.kLocksV2Mutex.Unlock()
 		lock := c.kLocksV2[key]
+		lock.Lock()
+		defer lock.Unlock()
 		if requester == owner && (lock == nil || !lock.refreshing) {
 			return false, owner, nil
 		}

--- a/k8s/core/configmap/configmap_lock_v2.go
+++ b/k8s/core/configmap/configmap_lock_v2.go
@@ -184,8 +184,8 @@ func (c *configMap) IsKeyLocked(key, requester string) (bool, string, error) {
 			return false, "", nil
 		}
 		c.kLocksV2Mutex.Lock()
-		defer c.kLocksV2Mutex.Unlock()
 		lock := c.kLocksV2[key]
+		c.kLocksV2Mutex.Unlock()
 		lock.Lock()
 		defer lock.Unlock()
 		if requester == owner && (lock == nil || !lock.refreshing) {

--- a/k8s/core/configmap/types.go
+++ b/k8s/core/configmap/types.go
@@ -79,10 +79,11 @@ type configMap struct {
 }
 
 type k8sLock struct {
-	v1LockGen uint64
-	done      chan struct{}
-	unlocked  bool
-	id        string
+	v1LockGen  uint64
+	done       chan struct{}
+	unlocked   bool
+	refreshing bool
+	id         string
 	sync.Mutex
 }
 
@@ -112,7 +113,7 @@ type ConfigMap interface {
 	// UnlockWithKey unlocks the given key in the configMap.
 	UnlockWithKey(key string) error
 	// IsKeyLocked returns if the given key is locked, and if so, by which owner.
-	IsKeyLocked(key string) (bool, string, error)
+	IsKeyLocked(key, requester string) (bool, string, error)
 
 	// PatchKeyLocked updates the specified key in the configMap. It verifies that
 	// the lock is still held by the specified owner. Lock needs to be held by the lockOwner


### PR DESCRIPTION
**What this PR does / why we need it**:
Suppose a key is locked by a owner before it expires. The owner asks whether the key is locked, we check whether a goroutine that refreshes the lock expiration time exists. If yes, we tell it it's locked by you. If the goroutine doesn't exist, we tell it it's unlocked. So the "owner" will try to grab the lock in which a goroutine will be spawned. During this time, if someone else asks whether the key is locked, we turn them away saying it's locked by someone else.

**Which issue(s) this PR fixes** (optional)
https://purestorage.atlassian.net/browse/PWX-38936


