### PR TITLE
PWX-39305 fix lock object being nil after restart

### DIFF
--- a/k8s/core/configmap/configmap_lock_v2.go
+++ b/k8s/core/configmap/configmap_lock_v2.go
@@ -186,8 +186,10 @@ func (c *configMap) IsKeyLocked(key, requester string) (bool, string, error) {
 		c.kLocksV2Mutex.Lock()
 		lock := c.kLocksV2[key]
 		c.kLocksV2Mutex.Unlock()
-		lock.Lock()
-		defer lock.Unlock()
+		if lock != nil {
+			lock.Lock()
+			defer lock.Unlock()
+		}
 		if requester == owner && (lock == nil || !lock.refreshing) {
 			return false, owner, nil
 		}

--- a/k8s/core/configmap/configmap_lock_v2.go
+++ b/k8s/core/configmap/configmap_lock_v2.go
@@ -186,11 +186,15 @@ func (c *configMap) IsKeyLocked(key, requester string) (bool, string, error) {
 		c.kLocksV2Mutex.Lock()
 		lock := c.kLocksV2[key]
 		c.kLocksV2Mutex.Unlock()
-		if lock != nil {
-			lock.Lock()
-			defer lock.Unlock()
+		if lock == nil {
+			if requester == owner {
+				return false, owner, nil
+			}
+			return true, owner, nil
 		}
-		if requester == owner && (lock == nil || !lock.refreshing) {
+		lock.Lock()
+		defer lock.Unlock()
+		if requester == owner && !lock.refreshing {
 			return false, owner, nil
 		}
 		return true, owner, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Only lock the lock if object is not nil. The object is nil after a restart.

**Which issue(s) this PR fixes** (optional)
Closes #39305

**Test done**
The UT without fix:
```
root@ip-10-13-182-237:~/workspace/git/go/src/github.com/portworx/sched-ops# go test -timeout 30s -run ^TestIsKeyLocked$ github.com/portworx/sched-ops/k8s/core/configmap -count=1
time="2024-09-23T17:26:13Z" level=info msg="Lock from owner 'is-key-locked-id1' is expired, now claiming for new owner 'is-key-locked-id1'" Error="<nil>" Function=checkAndTakeLock Key=is-key-locked-key Module=ConfigMap Name=px-configmaps-lock-is-key-locked-test Owner=is-key-locked-id1
time="2024-09-23T17:26:19Z" level=info msg="Lock from owner 'is-key-locked-id1' is expired, now claiming for new owner 'is-key-locked-id1'" Error="<nil>" Function=checkAndTakeLock Key=is-key-locked-key Module=ConfigMap Name=px-configmaps-lock-is-key-locked-test Owner=is-key-locked-id1
--- FAIL: TestIsKeyLocked (0.48s)
    configmap_test.go:103: Deleting configmap: kube-system/px-configmaps-lock-is-key-locked-test
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x14286c8]

goroutine 35 [running]:
testing.tRunner.func1.2({0x15ba600, 0x2680df0})
        /usr/local/go/src/testing/testing.go:1545 +0x238
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1548 +0x397
panic({0x15ba600?, 0x2680df0?})
        /usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/portworx/sched-ops/k8s/core/configmap.(*configMap).IsKeyLocked(0xc000402000, {0x17c7ab9, 0x11}, {0x17c7a97, 0x11})
        /root/workspace/git/go/src/github.com/portworx/sched-ops/k8s/core/configmap/configmap_lock_v2.go:189 +0x2c8
github.com/portworx/sched-ops/k8s/core/configmap.TestIsKeyLocked(0x0?)
        /root/workspace/git/go/src/github.com/portworx/sched-ops/k8s/core/configmap/configmap_lock_v2_test.go:485 +0xa1d
testing.tRunner(0xc000351040, 0x1890798)
        /usr/local/go/src/testing/testing.go:1595 +0xff
created by testing.(*T).Run in goroutine 1
        /usr/local/go/src/testing/testing.go:1648 +0x3ad
FAIL    github.com/portworx/sched-ops/k8s/core/configmap        0.501s
FAIL
```
With fix:
```
root@ip-10-13-182-237:~/workspace/git/go/src/github.com/portworx/sched-ops# go test -timeout 30s -run ^TestIsKeyLocked$ github.com/portworx/sched-ops/k8s/core/configmap -count=1
ok      github.com/portworx/sched-ops/k8s/core/configmap        0.623s
```
