### PR TITLE
PWX-39372: Refresh lock if the owner is same while trying to take lock

### DIFF
--- a/k8s/core/configmap/configmap_lock_v2.go
+++ b/k8s/core/configmap/configmap_lock_v2.go
@@ -315,6 +315,12 @@ func (c *configMap) checkAndTakeLock(
 		return owner, nil
 	}
 
+	if currentOwner == owner {
+		// If the current owner is the same as the provided owner, refresh the lock
+		lockExpirations[key] = time.Now().Add(k8sTTL)
+		return owner, nil
+	}
+
 	if time.Now().Before(lockExpirations[key]) {
 		return lockOwners[key], ErrConfigMapLocked
 	}

--- a/k8s/core/configmap/configmap_lock_v2.go
+++ b/k8s/core/configmap/configmap_lock_v2.go
@@ -183,18 +183,7 @@ func (c *configMap) IsKeyLocked(key, requester string) (bool, string, error) {
 		if time.Now().After(expiration) {
 			return false, "", nil
 		}
-		c.kLocksV2Mutex.Lock()
-		lock := c.kLocksV2[key]
-		c.kLocksV2Mutex.Unlock()
-		if lock == nil {
-			if requester == owner {
-				return false, owner, nil
-			}
-			return true, owner, nil
-		}
-		lock.Lock()
-		defer lock.Unlock()
-		if requester == owner && !lock.refreshing {
+		if c.ifRequesterIsLockOwnerWithoutGoroutine(requester, owner, key) {
 			return false, owner, nil
 		}
 		return true, owner, nil
@@ -315,13 +304,11 @@ func (c *configMap) checkAndTakeLock(
 		return owner, nil
 	}
 
-	if currentOwner == owner {
-		// If the current owner is the same as the provided owner, refresh the lock
-		lockExpirations[key] = time.Now().Add(k8sTTL)
-		return owner, nil
-	}
-
 	if time.Now().Before(lockExpirations[key]) {
+		if c.ifRequesterIsLockOwnerWithoutGoroutine(owner, currentOwner, key) {
+			lockExpirations[key] = time.Now().Add(k8sTTL)
+			return owner, nil
+		}
 		return lockOwners[key], ErrConfigMapLocked
 	}
 
@@ -447,4 +434,21 @@ func (c *configMap) checkLockTimeout(holdTimeout time.Duration, startTime time.T
 			dbg.Panicf(panicMsg)
 		}
 	}
+}
+
+// check whether the requester is the owner of the lock in configmap but has no goroutine
+// to refresh the lock expiration time
+func (c *configMap) ifRequesterIsLockOwnerWithoutGoroutine(requester, owner, key string) bool {
+	c.kLocksV2Mutex.Lock()
+	lock := c.kLocksV2[key]
+	c.kLocksV2Mutex.Unlock()
+	if lock == nil {
+		return requester == owner
+	}
+	lock.Lock()
+	defer lock.Unlock()
+	if requester == owner && !lock.refreshing {
+		return true
+	}
+	return false
 }

--- a/k8s/core/configmap/configmap_lock_v2_test.go
+++ b/k8s/core/configmap/configmap_lock_v2_test.go
@@ -226,7 +226,7 @@ func TestCMLockRefreshV2(t *testing.T) {
 			err = cm.LockWithKey(id1, key1)
 			require.NoError(t, err, "Unexpected error in LockWithKey(id1,key1)")
 
-			require.True(t, reentrantCheck.CompareAndSwap(false, true), "Reentrant lock detected")
+			require.False(t, reentrantCheck.CompareAndSwap(false, true), "Reentrant lock detected")
 
 			val := fmt.Sprintf("val%d", i)
 			err = cm.PatchKeyLocked(false, id1, key1, val)

--- a/k8s/core/configmap/configmap_lock_v2_test.go
+++ b/k8s/core/configmap/configmap_lock_v2_test.go
@@ -226,7 +226,7 @@ func TestCMLockRefreshV2(t *testing.T) {
 			err = cm.LockWithKey(id1, key1)
 			require.NoError(t, err, "Unexpected error in LockWithKey(id1,key1)")
 
-			require.False(t, reentrantCheck.CompareAndSwap(false, true), "Reentrant lock detected")
+			require.True(t, reentrantCheck.CompareAndSwap(false, true), "Reentrant lock detected")
 
 			val := fmt.Sprintf("val%d", i)
 			err = cm.PatchKeyLocked(false, id1, key1, val)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
`checkAndTakeLock` function must refresh the lock if owner is same instead of giving `ErrConfigMapLocked`

**Which issue(s) this PR fixes** (optional)
Closes #PWX-39372

**Manual Testing**

Restarted portworx here

```
Sep 25 15:54:11 ip-10-13-178-115.pwx.purestorage.com systemd[1]: Stopping Portworx OCI Container...
Sep 25 15:54:12 ip-10-13-178-115.pwx.purestorage.com portworx[2392695]: 2024-09-25 15:54:12,310 WARN received SIGTERM indicating exit request
Sep 25 15:54:12 ip-10-13-178-115.pwx.purestorage.com portworx[2392695]: 2024-09-25 15:54:12,311 INFO waiting for cron, px-etcd, relayd, lttng, cache_mon, exec, px-diag, px-healthmon, pxdaemon, px-ns, px_event_listener to die
Sep 25 15:54:15 ip-10-13-178-115.pwx.purestorage.com portworx[2392695]: 2024-09-25 15:54:15,315 INFO waiting for cron, px-etcd, relayd, lttng, cache_mon, exec, px-diag, px-healthmon, pxdaemon, px-ns, px_event_listener to die
Sep 25 15:54:18 ip-10-13-178-115.pwx.purestorage.com portworx[2392695]: 2024-09-25 15:54:18,319 INFO waiting for cron, px-etcd, relayd, lttng, cache_mon, exec, px-diag, px-healthmon, pxdaemon, px-ns, px_event_listener to die
Sep 25 15:54:21 ip-10-13-178-115.pwx.purestorage.com portworx[2392695]: 2024-09-25 15:54:21,324 INFO waiting for cron, px-etcd, relayd, lttng, cache_mon, exec, px-diag, px-healthmon, pxdaemon, px-ns, px_event_listener to die
Sep 25 15:54:22 ip-10-13-178-115.pwx.purestorage.com portworx[2392695]: 2024-09-25 15:54:22,325 WARN killing 'px_event_listener' (1368) with SIGKILL
Sep 25 15:54:22 ip-10-13-178-115.pwx.purestorage.com portworx[2392695]: 2024-09-25 15:54:22,326 INFO stopped: px_event_listener (terminated by SIGKILL)
Sep 25 15:54:22 ip-10-13-178-115.pwx.purestorage.com portworx[2392695]: 2024-09-25 15:54:22,332 INFO stopped: px-ns (terminated by SIGTERM)
Sep 25 15:54:22 ip-10-13-178-115.pwx.purestorage.com portworx[2392695]: PXPROCS[INFO]: Received SIGTERM. Exiting PX gracefully....
```

PX comes up in the first go without having to take a lock again as it is already locked

```
Sep 25 15:55:13 ip-10-13-178-115.pwx.purestorage.com portworx[2541327]: time="2024-09-25T15:55:13Z" level=info msg="Taking lock on locally attached driveset 'b7ea30c5-9939-4431-953e-bbb2a71071bd' as owner 'ip-10-13-178-115.pwx.purestorage.com'" file="pure_storage.go:957" component=porx/storage/hal/provider/pure
Sep 25 15:55:13 ip-10-13-178-115.pwx.purestorage.com portworx[2541327]: time="2024-09-25T15:55:13Z" level=info msg="Following Drive Set is attached on this node (b7ea30c5-9939-4431-953e-bbb2a71071bd): &{map[7d48742a2f:{pure-block 60 7d48742a2f 86a42417-55e3-45e2-9172-3118a5405610 /dev/mapper/3624a9370ea876434795b4b540018701c 0 0 data In Use map[portworx.io/flasharray-id:ea876434-795b-4b54-bdb4-3a081964051d portworx.io/flasharray-management-endpoint:dogfood-hotdog.dev.purestorage.com portworx.io/flasharray-name:dogfood-hotdog] map[]   ea876434795b4b540018701c} e8c4576829:{pure-block 50 e8c4576829 f18edb51-6a34-4647-87f4-5b7b817d5481 /dev/mapper/3624a9370ea876434795b4b540018701b 0 0 data In Use map[portworx.io/flasharray-id:ea876434-795b-4b54-bdb4-3a081964051d portworx.io/flasharray-management-endpoint:dogfood-hotdog.dev.purestorage.com portworx.io/flasharray-name:dogfood-hotdog] map[]   ea876434795b4b540018701b}] b7ea30c5-9939-4431-953e-bbb2a71071bd  ip-10-13-178-115.pwx.purestorage.com 0 2024-09-23 06:59:01.882542309 +0000 UTC ip-10-13-178-115.pwx.purestorage.com default In Use 0xc0008ca868}" file="cloud_drive.go:1117" component=porx/storage/hal/provider
Sep 25 15:55:13 ip-10-13-178-115.pwx.purestorage.com portworx[2541327]: time="2024-09-25T15:55:13Z" level=info msg="Drive ID: e8c4576829 Drive Path: /dev/mapper/3624a9370ea876434795b4b540018701b Drive Size: 50" file="cloud_drive.go:1145" component=porx/storage/hal/provider
Sep 25 15:55:13 ip-10-13-178-115.pwx.purestorage.com portworx[2541327]: time="2024-09-25T15:55:13Z" level=info msg="Drive ID: 7d48742a2f Drive Path: /dev/mapper/3624a9370ea876434795b4b540018701c Drive Size: 60" file="cloud_drive.go:1145" component=porx/storage/hal/provider
```

After this locks are refreshed properly as well

```
kn get cm px-pure-cloud-drive -ojson| jq -r '.data."px-lock"' | jq .
[
  {
    "owner": "ip-10-13-184-237.pwx.purestorage.com",
    "key": "d159dc9a-b774-4e6b-b6e1-4d1b359fdca3",
    "expiration": "2024-09-25T16:10:22.689310313Z"
  },
  {
    "owner": "ip-10-13-178-110.pwx.purestorage.com",
    "key": "1a9b127f-153c-44c5-b999-1b2cf46ecd7b",
    "expiration": "2024-09-25T16:10:09.008619687Z"
  },
  {
    "owner": "ip-10-13-180-104.pwx.purestorage.com",
    "key": "01a77c45-f2a6-438c-9ce4-e6732f5a30f3",
    "expiration": "2024-09-25T16:10:16.698443404Z"
  },
  {
    "owner": "ip-10-13-178-115.pwx.purestorage.com",
    "key": "b7ea30c5-9939-4431-953e-bbb2a71071bd",
    "expiration": "2024-09-25T16:10:13.87513606Z"
  }
]
```

**Special notes for your reviewer**:

