### PR TITLE
[PWX-38627] Stop logging Conflict error for configmap lock

### DIFF
--- a/k8s/core/configmap/configmap_lock_v2.go
+++ b/k8s/core/configmap/configmap_lock_v2.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -400,7 +401,8 @@ func (c *configMap) refreshLock(id, key string) {
 									" [ID %v] [Key %v] [Err: %v] [Current Refresh: %v] [Previous Refresh: %v]",
 								isConflictErrCount, id, key, err, currentRefresh, prevRefresh)
 						}
-						// try refreshing again
+						// try refreshing again after a random sleep so nodes wouldn'e entangle for too long
+						time.Sleep(lockSleepDuration + time.Duration(rand.Intn(lockRandomSleepDurationMaxMillisecond))*time.Millisecond)
 						continue
 					}
 					configMapLog(fn, c.name, "", key, err).Errorf(

--- a/k8s/core/configmap/configmap_lock_v2.go
+++ b/k8s/core/configmap/configmap_lock_v2.go
@@ -401,7 +401,7 @@ func (c *configMap) refreshLock(id, key string) {
 									" [ID %v] [Key %v] [Err: %v] [Current Refresh: %v] [Previous Refresh: %v]",
 								isConflictErrCount, id, key, err, currentRefresh, prevRefresh)
 						}
-						// try refreshing again after a random sleep so nodes wouldn'e entangle for too long
+						// try refreshing again after a random sleep so nodes wouldn't entangle for too long
 						time.Sleep(lockSleepDuration + time.Duration(rand.Intn(lockRandomSleepDurationMaxMillisecond))*time.Millisecond)
 						continue
 					}

--- a/k8s/core/configmap/configmap_lock_v2.go
+++ b/k8s/core/configmap/configmap_lock_v2.go
@@ -387,12 +387,19 @@ func (c *configMap) refreshLock(id, key string) {
 		select {
 		case <-refresh.C:
 			lock.Lock()
-
+			isConflictErrCount := 0
 			for !lock.unlocked {
 				c.checkLockTimeout(c.defaultLockHoldTimeout, startTime, id)
 				currentRefresh = time.Now()
 				if _, err := c.tryLock(id, key, true); err != nil {
 					if k8s_errors.IsConflict(err) {
+						isConflictErrCount++
+						if isConflictErrCount%10 == 0 {
+							configMapLog(fn, c.name, "", key, err).Errorf(
+								"Error refreshing lock due to conflict from concurrent configmap updates. retries: %v."+
+									" [ID %v] [Key %v] [Err: %v] [Current Refresh: %v] [Previous Refresh: %v]",
+								isConflictErrCount, id, key, err, currentRefresh, prevRefresh)
+						}
 						// try refreshing again
 						continue
 					}

--- a/k8s/core/configmap/configmap_test.go
+++ b/k8s/core/configmap/configmap_test.go
@@ -19,7 +19,7 @@ func TestGetConfigMap(t *testing.T) {
 	configData := map[string]string{
 		"key1": "val1",
 	}
-	cm, err := New("px-configmaps-test", configData, testLockTimeout, 5, 0, 0)
+	cm, err := New("px-configmaps-get-test", configData, testLockTimeout, 5, 0, 0)
 	require.NoError(t, err, "Unexpected error in creating configmap")
 
 	resultMap, err := cm.Get()
@@ -35,7 +35,7 @@ func TestDeleteConfigMap(t *testing.T) {
 		"key1": "val1",
 	}
 
-	cm, err := New("px-configmaps-test", configData, testLockTimeout, 5, 0, 0)
+	cm, err := New("px-configmaps-delete-test", configData, testLockTimeout, 5, 0, 0)
 	require.NoError(t, err, "Unexpected error in creating configmap")
 
 	err = cm.Delete()
@@ -48,7 +48,7 @@ func TestIncrementGeneration(t *testing.T) {
 	configData := map[string]string{
 		"key1": "1",
 	}
-	cmIntf, err := New("px-configmaps-test", configData, testLockTimeout, 5, 0, 0)
+	cmIntf, err := New("px-configmaps-increment-generation-test", configData, testLockTimeout, 5, 0, 0)
 	require.NoError(t, err, "Unexpected error in creating configmap")
 
 	cm := cmIntf.(*configMap)

--- a/k8s/core/configmap/types.go
+++ b/k8s/core/configmap/types.go
@@ -45,9 +45,10 @@ const (
 	// the configmap data is updated via PatchKeyLocked or DeleteKeyLocked. This is used for diagnostics purposes only.
 	pxGenerationKey = "px-generation"
 
-	lockSleepDuration     = 1 * time.Second
-	configMapUserLabelKey = "user"
-	maxConflictRetries    = 3
+	lockSleepDuration                     = 1 * time.Second
+	lockRandomSleepDurationMaxMillisecond = 1000
+	configMapUserLabelKey                 = "user"
+	maxConflictRetries                    = 3
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:
Since we already have warning log if it takes 1.5 times of the refresh duration, the conflict error logging can be too spammy. Thus stop logging this error.

**Which issue(s) this PR fixes** (optional)
Closes #38627

