### PR TITLE
PWX-40447: add update job utility

### DIFF
--- a/k8s/batch/jobs.go
+++ b/k8s/batch/jobs.go
@@ -18,6 +18,8 @@ type JobOps interface {
 	GetJob(name, namespace string) (*batchv1.Job, error)
 	// DeleteJob deletes the job with given namespace and name
 	DeleteJob(name, namespace string) error
+	// UpdateJob updates the given job
+	UpdateJob(job *batchv1.Job) (*batchv1.Job, error)
 	// DeleteJobWithForce deletes the job with given namespace and name
 	DeleteJobWithForce(name, namespace string) error
 	// ValidateJob validates if the job with given namespace and name succeeds.
@@ -54,6 +56,14 @@ func (c *Client) DeleteJob(name, namespace string) error {
 	return c.batch.Jobs(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
+}
+
+// UpdateJob updates the given job.
+func (c *Client) UpdateJob(job *batchv1.Job) (*batchv1.Job, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.batch.Jobs(job.Namespace).Update(context.TODO(), job, metav1.UpdateOptions{})
 }
 
 // DeleteJobWithForce deletes the job with given namespace and name with force option


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds utility to update `Job` Kubernetes resource. Required for [PWX-40447](https://purestorage.atlassian.net/browse/PWX-40447).

**Which issue(s) this PR fixes** (optional)
Closes [PWX-40447](https://purestorage.atlassian.net/browse/PWX-40447)


[PWX-40447]: https://purestorage.atlassian.net/browse/PWX-40447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PWX-40447]: https://purestorage.atlassian.net/browse/PWX-40447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ