### PR TITLE
PWX-40370: Add method to extend v2 lock expiration to 100y

### DIFF
--- a/k8s/core/configmap/configmap_lock_v2.go
+++ b/k8s/core/configmap/configmap_lock_v2.go
@@ -194,6 +194,56 @@ func (c *configMap) IsKeyLocked(key, requester string) (bool, string, error) {
 	return false, "", nil
 }
 
+// DeprecateKeyInV2Lock sets the expiration of a key in a V2 lock to 100 years from now for the purpose of deprecation.
+func (c *configMap) DeprecateKeyInV2Lock(key string) error {
+	fn := "DeprecateKeyInV2Lock"
+	var err error
+	isConflictErrCount := 0
+	for count := uint(0); count < c.lockAttempts; count++ {
+		cm, err := core.Instance().GetConfigMap(
+			c.name,
+			k8sSystemNamespace,
+		)
+		if err != nil {
+			// A ConfigMap should always be created.
+			return err
+		}
+
+		if cm.Data == nil {
+			cm.Data = make(map[string]string)
+		}
+
+		lockIDs, lockExpirations, err := c.parseLocks(cm)
+		if err != nil {
+			return fmt.Errorf("failed to get locks from configmap: %v", err)
+		}
+		if _, ok := lockIDs[key]; !ok {
+			// Key does not exist in the lock. Nothing to deprecate
+			return nil
+		}
+		lockExpirations[key] = time.Now().Add(24 * time.Hour * 365 * 100)
+		err = c.generateConfigMapData(cm, lockIDs, lockExpirations)
+		if err != nil {
+			return err
+		}
+		if _, err = c.updateConfigMap(cm); err != nil {
+			if k8s_errors.IsConflict(err) {
+				isConflictErrCount++
+				if isConflictErrCount%10 == 0 {
+					configMapLog(fn, c.name, "", key, err).Errorf(
+						"Error deprecating key in the cm v2 lock due to conflict from concurrent configmap updates. retries: %v."+
+							" [Key %v] [Err: %v]", isConflictErrCount, key, err)
+				}
+			} else {
+				configMapLog(fn, c.name, "", key, err).Errorf(
+					"Error deprecating key in the cm v2 lock. [Key %v] [Err: %v]. retries: %v", key, err, count)
+			}
+			time.Sleep(lockSleepDuration + time.Duration(rand.Intn(lockRandomSleepDurationMaxMillisecond))*time.Millisecond)
+		}
+	}
+	return err
+}
+
 func (c *configMap) tryLock(owner string, key string, refresh bool) (string, error) {
 	// Get the existing ConfigMap
 	cm, err := core.Instance().GetConfigMap(

--- a/k8s/core/configmap/configmap_lock_v2_test.go
+++ b/k8s/core/configmap/configmap_lock_v2_test.go
@@ -494,3 +494,46 @@ func TestIsKeyLocked(t *testing.T) {
 	err = cm.Delete()
 	require.NoError(t, err, "Unexpected error on Delete")
 }
+
+func TestDeprecateKeyInV2Lock(t *testing.T) {
+	setUpConfigMapTestCluster(t)
+	cmIntf, err := New("px-configmaps-lock-deprecate-key-in-v2-lock-test", nil, testLockTimeout, testLockAttempts, testLockRefreshDuration, testLockTTL)
+	require.NoError(t, err, "Unexpected error on New")
+	cm := cmIntf.(*configMap)
+
+	// Brand new cluster with no existing lock
+	err = cm.DeprecateKeyInV2Lock("key1")
+	require.NoError(t, err, "Unexpected error in DeprecateKeyInV2Lock")
+	rawCm, err := coreops.Instance().GetConfigMap(cm.name, k8sSystemNamespace)
+	require.NoError(t, err)
+	keyIDs, keyExpirations, err := cm.parseLocks(rawCm)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(keyIDs))
+	require.Equal(t, 0, len(keyExpirations))
+
+	// Deprecate an existing key
+	// patch time.Now()
+	curTime := time.Now().UTC()
+	timePatch, err := mpatch.PatchMethod(time.Now, func() time.Time { return curTime })
+	require.NoError(t, err, "Failed to patch time.Now()")
+	defer timePatch.Unpatch()
+
+	id := "deprecate-key-id"
+	key := "deprecate-key-key"
+	err = cm.LockWithKey(id, key)
+	require.NoError(t, err)
+
+	err = cm.DeprecateKeyInV2Lock(key)
+	require.NoError(t, err)
+	rawCm, err = coreops.Instance().GetConfigMap(cm.name, k8sSystemNamespace)
+	require.NoError(t, err)
+	keyIDs, keyExpirations, err = cm.parseLocks(rawCm)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(keyIDs))
+	require.Equal(t, 1, len(keyExpirations))
+	require.Equal(t, id, keyIDs[key])
+	require.Equal(t, curTime.Add(24*time.Hour*365*100), keyExpirations[key])
+
+	err = cm.Delete()
+	require.NoError(t, err, "Unexpected error on Delete")
+}

--- a/k8s/core/configmap/types.go
+++ b/k8s/core/configmap/types.go
@@ -128,6 +128,9 @@ type ConfigMap interface {
 	Get() (map[string]string, error)
 	// Delete deletes the configMap
 	Delete() error
+
+	// DeprecateV2Lock deprecates a key in a V2 lock
+	DeprecateKeyInV2Lock(key string) error
 }
 
 // lockData structs are serialized into JSON and stored as a list inside a ConfigMap.


### PR DESCRIPTION
Same change as https://github.com/pure-px/sched-ops/pull/423, but targeting this repo because right now this one is being used by px